### PR TITLE
✨第十四回: 实现 proxyRefs 功能

### DIFF
--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -47,9 +47,34 @@ export function isRef(ref) {
 }
 
 export function unRef(ref) {
+    // 如果是 ref 对象，返回 ref 下的 value 值
+    // 否则直接返回
     return isRef(ref) ? ref.value : ref
 }
 
 export function ref(value) {
     return new RefImpl(value)
+}
+
+export function proxyRefs(objectWithRefs) {
+   return new Proxy(objectWithRefs, {
+        get(target, key) {
+            // 获取属性值，如果是 ref，节省 .value 步骤直接获取
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age
+            return unRef(Reflect.get(target, key))
+        },
+        set(target, key, value) {
+            // 设置属性值，如果是 ref，节省 .value 步骤直接设置
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age = 20
+            // 如果 target[key] 是 ref, 但 value 不是 ref, 将 value 赋值到 target[key].value，以节省 .value 步骤
+            if(isRef(target[key]) && !isRef(value)) {
+                return target[key].value = value
+            } else {
+                // 其他情况直接赋值
+                // 同是 ref 赋值：const user = proxyRefs({ age: ref(18) }) -> user.age = ref(20)
+                // 非 ref 赋值 ref：const user = proxyRefs({ age: 18 }) -> user.age = ref(20)
+                return Reflect.set(target, key, value)
+            }
+        }
+    })
 }

--- a/src/reactivity/tests/ref.spec.ts
+++ b/src/reactivity/tests/ref.spec.ts
@@ -1,6 +1,6 @@
 import { effect } from "../effect"
 import { reactive } from "../reactive"
-import { isRef, ref, unRef } from "../ref"
+import { isRef, proxyRefs, ref, unRef } from "../ref"
 
 describe('ref', () => {
     it('happy path', () => {
@@ -54,10 +54,33 @@ describe('ref', () => {
         const origin = 'origin'
         const user = ref('user')
         const obj = ref({ age: 18 })
+        expect(unRef(1)).toBe(1)
         expect(unRef(origin)).toBe('origin')
         expect(unRef(user)).toBe('user')
         expect(unRef(obj)).toHaveProperty('age')
         expect(unRef(obj).age).toBe(18)
-        expect(unRef(1)).toBe(1)
+    })
+
+    it('proxyRefs', () => {
+        const origin = { 
+            age: ref(18),
+            name: 'leo' as any
+        }
+        const proxyUser = proxyRefs(origin)
+        expect(origin.age.value).toBe(18)
+        expect(proxyUser.age).toBe(18)
+        expect(proxyUser.name).toBe('leo')
+        // set normal value
+        proxyUser.age = 20
+        expect(proxyUser.age).toBe(20)
+        expect(origin.age.value).toBe(20)
+        // set ref value
+        proxyUser.age = ref(30)
+        expect(proxyUser.age).toBe(30)
+        expect(origin.age.value).toBe(30)
+        // change name to ref
+        proxyUser.name = ref('joe')
+        expect(proxyUser.name).toBe('joe')
+        expect(origin.name.value).toBe('joe')
     })
 })


### PR DESCRIPTION
**为操作 ref 变量 get/set 时，节省 .value 操作**
get 时用 unRef 获取 value
set 时判断：
1. 当前 target[key] 为 ref 类型，赋值 value 非 ref时, 直接将 value 赋值给ref.value：target[key].value = value
2. 其他情况直接赋值，target[key] = value 或者 Reflect.set(target, key, value) 如：
- 同是 ref 赋值：const user = proxyRefs({ age: ref(18) }) -> user.age = ref(20)
- 非 ref 赋值 ref：const user = proxyRefs({ age: 18 }) -> user.age = ref(20)