### PR TITLE
✨第十九回: 实现组件代理对象 (setupState & $el)

### DIFF
--- a/example/hellow world/App.js
+++ b/example/hellow world/App.js
@@ -2,22 +2,23 @@ import { h } from '../../lib/yolo-vue.esm.js'
 
 export const App = {
     render() {
-        return h(
+    window.self = this
+    return h(
             'div', 
             {
                 id: 'test'
             },
-            // `hello ${this.msg}!`
+            `Hello ${this.msg}!`
             //`hello world!`
-            [
-                h('p', {class: 'red'}, '红色'),
-                h('p', {class: 'green'}, '绿色')
-            ]
+            // [
+            //     h('p', {class: 'red'}, '红色'),
+            //     h('p', {class: 'green'}, '绿色')
+            // ]
         )
     },
     setup() {
         return {
-            msg: 'world'
+            msg: 'World'
         }
     }
 }

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -4,7 +4,8 @@ function createVNode(type, props, children) {
     return {
         type,
         props,
-        children
+        children,
+        el: null
     };
 }
 
@@ -12,11 +13,29 @@ const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
 };
 
+const publicPropertiesMap = {
+    $el: (i) => i.vnode.el
+    // $data
+    // ...
+};
+const publicInstanceProxyHandlers = {
+    get({ _: instance }, key) {
+        const { setupState } = instance;
+        if (key in setupState) {
+            return Reflect.get(setupState, key);
+        }
+        if (key in publicPropertiesMap) {
+            return Reflect.get(publicPropertiesMap, key)(instance);
+        }
+    }
+};
+
 // 创建组件实例
 function createComponentInstance(vnode) {
     const component = {
         vnode,
-        type: vnode.type
+        type: vnode.type,
+        setupState: {}
     };
     return component;
 }
@@ -29,6 +48,9 @@ function setupComponent(instance) {
 // 安装组件状态
 function setupStatufulComponent(instance) {
     const component = instance.type;
+    // 代理组件对象（setupState、$el、$data...）
+    instance.proxy = new Proxy({ _: instance }, publicInstanceProxyHandlers);
+    // 处理 setup 函数
     if (component.setup) {
         const setupResult = component.setup();
         handleSetupResult(instance, setupResult);
@@ -69,15 +91,15 @@ function processElement(vnode, container) {
 }
 // 挂载 Element
 function mountElement(vnode, container) {
-    debugger;
-    // create dom
-    const el = document.createElement(vnode.type);
+    // create el & save el to vnode
+    const el = (vnode.el = document.createElement(vnode.type));
     // children
     const { children } = vnode;
     if (typeof children === 'string') {
         el.textContent = children;
     }
     else if (typeof children === 'object') {
+        // handle multiple childrens
         mountChildren(vnode, el);
     }
     // props
@@ -85,9 +107,10 @@ function mountElement(vnode, container) {
     for (const key in props) {
         el.setAttribute(key, props[key]);
     }
-    // append to container
+    // el append to container
     container.append(el);
 }
+// 挂载 children 数组，循环调用 patch
 function mountChildren(vnode, container) {
     vnode.children.forEach(v => {
         patch(v, container);
@@ -98,15 +121,17 @@ function processComponent(vnode, container) {
     mountComponent(vnode, container);
 }
 // 挂载组件
-function mountComponent(vnode, container) {
-    const instance = createComponentInstance(vnode);
+function mountComponent(initialVNode, container) {
+    const instance = createComponentInstance(initialVNode);
     setupComponent(instance);
-    setupRenderEffect(instance, container);
+    setupRenderEffect(instance, initialVNode, container);
 }
 // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, container) {
-    const subTree = instance.render();
+function setupRenderEffect(instance, initialVNode, container) {
+    const { proxy } = instance;
+    const subTree = instance.render.call(proxy);
     patch(subTree, container);
+    initialVNode.el = subTree.el;
 }
 
 function createApp(rootComponent) {

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -2,7 +2,8 @@ function createVNode(type, props, children) {
     return {
         type,
         props,
-        children
+        children,
+        el: null
     };
 }
 
@@ -10,11 +11,29 @@ const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
 };
 
+const publicPropertiesMap = {
+    $el: (i) => i.vnode.el
+    // $data
+    // ...
+};
+const publicInstanceProxyHandlers = {
+    get({ _: instance }, key) {
+        const { setupState } = instance;
+        if (key in setupState) {
+            return Reflect.get(setupState, key);
+        }
+        if (key in publicPropertiesMap) {
+            return Reflect.get(publicPropertiesMap, key)(instance);
+        }
+    }
+};
+
 // 创建组件实例
 function createComponentInstance(vnode) {
     const component = {
         vnode,
-        type: vnode.type
+        type: vnode.type,
+        setupState: {}
     };
     return component;
 }
@@ -27,6 +46,9 @@ function setupComponent(instance) {
 // 安装组件状态
 function setupStatufulComponent(instance) {
     const component = instance.type;
+    // 代理组件对象（setupState、$el、$data...）
+    instance.proxy = new Proxy({ _: instance }, publicInstanceProxyHandlers);
+    // 处理 setup 函数
     if (component.setup) {
         const setupResult = component.setup();
         handleSetupResult(instance, setupResult);
@@ -67,15 +89,15 @@ function processElement(vnode, container) {
 }
 // 挂载 Element
 function mountElement(vnode, container) {
-    debugger;
-    // create dom
-    const el = document.createElement(vnode.type);
+    // create el & save el to vnode
+    const el = (vnode.el = document.createElement(vnode.type));
     // children
     const { children } = vnode;
     if (typeof children === 'string') {
         el.textContent = children;
     }
     else if (typeof children === 'object') {
+        // handle multiple childrens
         mountChildren(vnode, el);
     }
     // props
@@ -83,9 +105,10 @@ function mountElement(vnode, container) {
     for (const key in props) {
         el.setAttribute(key, props[key]);
     }
-    // append to container
+    // el append to container
     container.append(el);
 }
+// 挂载 children 数组，循环调用 patch
 function mountChildren(vnode, container) {
     vnode.children.forEach(v => {
         patch(v, container);
@@ -96,15 +119,17 @@ function processComponent(vnode, container) {
     mountComponent(vnode, container);
 }
 // 挂载组件
-function mountComponent(vnode, container) {
-    const instance = createComponentInstance(vnode);
+function mountComponent(initialVNode, container) {
+    const instance = createComponentInstance(initialVNode);
     setupComponent(instance);
-    setupRenderEffect(instance, container);
+    setupRenderEffect(instance, initialVNode, container);
 }
 // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, container) {
-    const subTree = instance.render();
+function setupRenderEffect(instance, initialVNode, container) {
+    const { proxy } = instance;
+    const subTree = instance.render.call(proxy);
     patch(subTree, container);
+    initialVNode.el = subTree.el;
 }
 
 function createApp(rootComponent) {

--- a/src/runtime-core/component.ts
+++ b/src/runtime-core/component.ts
@@ -1,8 +1,11 @@
+import { publicInstanceProxyHandlers } from "./componentPublicInstance"
+
 // 创建组件实例
 export function createComponentInstance(vnode: any) {
     const component = {
         vnode,
-        type: vnode.type
+        type: vnode.type,
+        setupState: {}
     }
     return component
 }
@@ -17,6 +20,11 @@ export function setupComponent(instance) {
 // 安装组件状态
 export function setupStatufulComponent(instance: any) {
     const component = instance.type
+    
+    // 代理组件对象（setupState、$el、$data...）
+    instance.proxy = new Proxy( { _: instance }, publicInstanceProxyHandlers)
+
+    // 处理 setup 函数
     if(component.setup) {
         const setupResult = component.setup()
         handleSetupResult(instance, setupResult)

--- a/src/runtime-core/componentPublicInstance.ts
+++ b/src/runtime-core/componentPublicInstance.ts
@@ -1,0 +1,17 @@
+const publicPropertiesMap = {
+    $el: (i)=> i.vnode.el
+    // $data
+    // ...
+}
+
+export const publicInstanceProxyHandlers = {
+    get({ _: instance }, key) {
+        const { setupState } = instance
+        if(key in setupState) {
+            return Reflect.get(setupState,key)
+        }
+        if (key in publicPropertiesMap) {
+            return Reflect.get(publicPropertiesMap,key)(instance)
+        }
+    }
+}

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -22,8 +22,8 @@ function processElement(vnode: any, container: any) {
 
 // 挂载 Element
 function mountElement(vnode: any, container: any) {
-    // create dom
-    const el = document.createElement(vnode.type) as Element
+    // create el & save el to vnode
+    const el = (vnode.el = document.createElement(vnode.type) as Element)
 
     // children
     const { children } = vnode
@@ -57,15 +57,17 @@ function processComponent(vnode, container) {
 }
 
 // 挂载组件
-function mountComponent(vnode, container) {
-    const instance = createComponentInstance(vnode)
+function mountComponent(initialVNode, container) {
+    const instance = createComponentInstance(initialVNode)
     setupComponent(instance)
-    setupRenderEffect(instance, container)
+    setupRenderEffect(instance, initialVNode, container)
 }
 
 // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, container) {
-    const subTree = instance.render()
+function setupRenderEffect(instance, initialVNode, container) {
+    const { proxy } = instance
+    const subTree = instance.render.call(proxy)
     patch(subTree, container)
+    initialVNode.el = subTree.el
 }
 

--- a/src/runtime-core/vnode.ts
+++ b/src/runtime-core/vnode.ts
@@ -2,6 +2,7 @@ export function createVNode(type, props?, children?) {
     return {
         type,
         props,
-        children
+        children,
+        el: null
     }
 }


### PR DESCRIPTION
**实现组件代理对象 (setupState & $el)**

**setupState：render -> this.name**

1. 在 `mountComponent -> setupComponent` 中给 `instance` 声明 `proxy` 属性，使用 `new Proxy` 代理组件对象 `get`，判断 `key` 返回对应值（setupState、$el、$data、...）

2. 在 `mountComponent -> setupRenderEffect` 中将 `instance.proxy` 绑定给 `render` 作用域：`instance.render.call(instance.proxy)`，方便在组件中 `render` 函数内调用 `this` 取值

**$el：render -> this.$el**
1. 在 `mountElement` 中保存创建的 `el` 对象到 `vnode.el`

2. 在 `mountComponent -> setupRenderEffect` 中，`patch` 执行结束，所有 `element  mount` 完毕后保存 `subTree.el` 到当前 `initialVNode.el`

3. `instance.proxy` 代理对象 `get` 函数，添加对 `$el` 的取值逻辑，如果触发 `get` 且取值 `key` 为 `'$el'`，即返回当前代理对象 `instance` 的 `vnode.el` 对象