### PR TITLE
✨第二十回: 实现 ShapeFlags & 二进制位运算

### DIFF
--- a/example/hellow world/App.js
+++ b/example/hellow world/App.js
@@ -8,12 +8,12 @@ export const App = {
             {
                 id: 'test'
             },
-            `Hello ${this.msg}!`
+            // `Hello ${this.msg}!`
             //`hello world!`
-            // [
-            //     h('p', {class: 'red'}, '红色'),
-            //     h('p', {class: 'green'}, '绿色')
-            // ]
+            [
+                h('p', {class: 'red'}, '红色'),
+                h('p', {class: 'green'}, '绿色')
+            ]
         )
     },
     setup() {

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -1,17 +1,32 @@
 'use strict';
 
+var ShapeFlags;
+(function (ShapeFlags) {
+    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
+    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
+    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
+    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+})(ShapeFlags || (ShapeFlags = {}));
+
 function createVNode(type, props, children) {
-    return {
+    const vnode = {
         type,
         props,
         children,
+        shapeFlag: getShapeFlag(type),
         el: null
     };
+    if (typeof children === 'string') {
+        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
+    }
+    else if (typeof children === 'object') {
+        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
+    }
+    return vnode;
 }
-
-const isObject = (val) => {
-    return val !== null && typeof (val) === 'object';
-};
+function getShapeFlag(type) {
+    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
+}
 
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
@@ -76,12 +91,13 @@ function render(vnode, container) {
     patch(vnode, container);
 }
 function patch(vnode, container) {
-    if (typeof vnode.type === 'string') {
-        // 判断 vnode 类型为 string：调用 processElement
+    const { shapeFlag } = vnode;
+    if (shapeFlag & ShapeFlags.ELEMENT) {
+        // 判断 vnode 类型为 ELEMENT：调用 processElement
         processElement(vnode, container);
     }
-    else if (isObject(vnode.type)) {
-        // 判断 vnode 类型为 object：调用 processComponent
+    else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
         processComponent(vnode, container);
     }
 }
@@ -94,11 +110,11 @@ function mountElement(vnode, container) {
     // create el & save el to vnode
     const el = (vnode.el = document.createElement(vnode.type));
     // children
-    const { children } = vnode;
-    if (typeof children === 'string') {
+    const { children, shapeFlag } = vnode;
+    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
         el.textContent = children;
     }
-    else if (typeof children === 'object') {
+    else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
         // handle multiple childrens
         mountChildren(vnode, el);
     }

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -1,15 +1,30 @@
+var ShapeFlags;
+(function (ShapeFlags) {
+    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
+    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
+    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
+    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+})(ShapeFlags || (ShapeFlags = {}));
+
 function createVNode(type, props, children) {
-    return {
+    const vnode = {
         type,
         props,
         children,
+        shapeFlag: getShapeFlag(type),
         el: null
     };
+    if (typeof children === 'string') {
+        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
+    }
+    else if (typeof children === 'object') {
+        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
+    }
+    return vnode;
 }
-
-const isObject = (val) => {
-    return val !== null && typeof (val) === 'object';
-};
+function getShapeFlag(type) {
+    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
+}
 
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
@@ -74,12 +89,13 @@ function render(vnode, container) {
     patch(vnode, container);
 }
 function patch(vnode, container) {
-    if (typeof vnode.type === 'string') {
-        // 判断 vnode 类型为 string：调用 processElement
+    const { shapeFlag } = vnode;
+    if (shapeFlag & ShapeFlags.ELEMENT) {
+        // 判断 vnode 类型为 ELEMENT：调用 processElement
         processElement(vnode, container);
     }
-    else if (isObject(vnode.type)) {
-        // 判断 vnode 类型为 object：调用 processComponent
+    else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
         processComponent(vnode, container);
     }
 }
@@ -92,11 +108,11 @@ function mountElement(vnode, container) {
     // create el & save el to vnode
     const el = (vnode.el = document.createElement(vnode.type));
     // children
-    const { children } = vnode;
-    if (typeof children === 'string') {
+    const { children, shapeFlag } = vnode;
+    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
         el.textContent = children;
     }
-    else if (typeof children === 'object') {
+    else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
         // handle multiple childrens
         mountChildren(vnode, el);
     }

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -1,3 +1,4 @@
+import { ShapeFlags } from "../shared/ShapeFlags"
 import { isObject } from "../shared/index"
 import { createComponentInstance, setupComponent } from "./component"
 
@@ -6,11 +7,12 @@ export function render(vnode, container) {
 }
 
 function patch(vnode, container) {
-    if (typeof vnode.type === 'string') {
-        // 判断 vnode 类型为 string：调用 processElement
+    const { shapeFlag } = vnode
+    if (shapeFlag & ShapeFlags.ELEMENT) {
+        // 判断 vnode 类型为 ELEMENT：调用 processElement
         processElement(vnode, container)
-    } else if( isObject(vnode.type)) {
-        // 判断 vnode 类型为 object：调用 processComponent
+    } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
         processComponent(vnode, container)
     }
 }
@@ -26,10 +28,10 @@ function mountElement(vnode: any, container: any) {
     const el = (vnode.el = document.createElement(vnode.type) as Element)
 
     // children
-    const { children } = vnode
-    if (typeof children === 'string') {
+    const { children, shapeFlag } = vnode
+    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
         el.textContent = children
-    } else if(typeof children === 'object') {
+    } else if(shapeFlag & ShapeFlags.ARRAY_CHILREN) {
         // handle multiple childrens
         mountChildren(vnode, el)
     }

--- a/src/runtime-core/vnode.ts
+++ b/src/runtime-core/vnode.ts
@@ -1,8 +1,23 @@
+import { ShapeFlags } from "../shared/ShapeFlags";
+
 export function createVNode(type, props?, children?) {
-    return {
+    const vnode = {
         type,
         props,
         children,
+        shapeFlag: getShapeFlag(type),
         el: null
     }
+
+    if(typeof children === 'string') {
+        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN
+    } else if(typeof children === 'object') {
+        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN
+    }
+
+    return vnode
+}
+
+export function getShapeFlag(type) {
+    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT
 }

--- a/src/shared/ShapeFlags.ts
+++ b/src/shared/ShapeFlags.ts
@@ -1,0 +1,6 @@
+export enum ShapeFlags {
+    ELEMENT = 1,
+    STATEFUL_COMPONENT = 1 << 1,
+    TEXT_CHILDREN = 1 << 2,
+    ARRAY_CHILREN = 1 << 3
+}


### PR DESCRIPTION
**实现 ShapeFlags & 二进制位运算**

1. 创建枚举 enum ShapeFlags 用于记录 `vnode` 标记，使用二进制方式设置枚举值；利用位运算符 `或 |、与 &` 可修改或匹配多个枚举值，方便管理使用
```javascript
export enum ShapeFlags {
    ELEMENT = 1, // 二进制：1
    STATEFUL_COMPONENT = 1 << 1, //  二进制： 10
    TEXT_CHILDREN = 1 << 2, // 二进制：100
    ARRAY_CHILREN = 1 << 3 // 二进制：1000
}
```
2. 在 `createVNode` 时，初始化设置当前 `shapeFlag` 标记（`ELEMENT` or `STATEFUL_COMPONENT`）、并判断 `children` 类型（`TEXT_CHILDREN` or `ARRAY_CHILREN`），使用位运算符修改合并标记

3. 使用位运算符 `"或 |"`（**两数逐个对比，都为 0 时返回 0**）合并修改 `shapeFlag` 值：`vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN`

4. 使用位运算符 `"与 &"`（**两数逐个对比，都为 1 时返回 1**）判断 `shapeFlag` 是否匹配枚举值：`vnode.shapeFlag & ShapeFlags.TEXT_CHILDREN`

**例如：**
1. 当 `vnode.shapeFlag = ShapeFlags.ELEMENT` 时，二进制值为 1

2. 使用 `"或 |"` 位运算符：执行 `vnode.shapeFlag = vnode.shapeFlag｜ShapeFlags.TEXT_CHILDREN` 后，`vnode.shapeFlag` 的二进制值为 **101（1 和 100 使用｜运算合并后的值）**

3. 使用 `"与 &"`位运算符：执行 `vnode.shapeFlag & ShapeFlags.TEXT_CHILDREN` **（101 & 100）后返回 1 则为 true**