### PR TITLE
✨第二十一回: 实现绑定事件功能

### DIFF
--- a/example/hellow world/App.js
+++ b/example/hellow world/App.js
@@ -6,7 +6,10 @@ export const App = {
     return h(
             'div', 
             {
-                id: 'test'
+                id: 'test',
+                onClick: ()=> {
+                    console.log('onClick')
+                }
             },
             // `Hello ${this.msg}!`
             //`hello world!`

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -28,6 +28,13 @@ function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
+const isOn = (key) => {
+    return /^on[A-z]/.test(key);
+};
+const getEventNameByKey = (key) => {
+    return key.slice(2).toLocaleLowerCase();
+};
+
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
     // $data
@@ -121,7 +128,12 @@ function mountElement(vnode, container) {
     // props
     const { props } = vnode;
     for (const key in props) {
-        el.setAttribute(key, props[key]);
+        if (isOn(key)) {
+            el.addEventListener(getEventNameByKey(key), props[key]);
+        }
+        else {
+            el.setAttribute(key, props[key]);
+        }
     }
     // el append to container
     container.append(el);

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -26,6 +26,13 @@ function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
+const isOn = (key) => {
+    return /^on[A-z]/.test(key);
+};
+const getEventNameByKey = (key) => {
+    return key.slice(2).toLocaleLowerCase();
+};
+
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
     // $data
@@ -119,7 +126,12 @@ function mountElement(vnode, container) {
     // props
     const { props } = vnode;
     for (const key in props) {
-        el.setAttribute(key, props[key]);
+        if (isOn(key)) {
+            el.addEventListener(getEventNameByKey(key), props[key]);
+        }
+        else {
+            el.setAttribute(key, props[key]);
+        }
     }
     // el append to container
     container.append(el);

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -1,5 +1,5 @@
 import { ShapeFlags } from "../shared/ShapeFlags"
-import { isObject } from "../shared/index"
+import { getEventNameByKey, isObject, isOn } from "../shared/index"
 import { createComponentInstance, setupComponent } from "./component"
 
 export function render(vnode, container) {
@@ -39,7 +39,11 @@ function mountElement(vnode: any, container: any) {
     // props
     const { props } = vnode
     for (const key in props) {
-       el.setAttribute(key, props[key])
+        if (isOn(key)) {
+            el.addEventListener(getEventNameByKey(key), props[key])
+        } else {
+            el.setAttribute(key, props[key])
+        }
     }
 
     // el append to container

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -7,3 +7,11 @@ export const isObject = (val) => {
 export const hasChanged = (value, newValue) => {
     return !Object.is(value, newValue)
 }
+
+export const isOn = (key: string) => {
+    return /^on[A-z]/.test(key)
+}
+
+export const getEventNameByKey = (key: string) => {
+    return key.slice(2).toLocaleLowerCase()
+}


### PR DESCRIPTION
**实现绑定事件功能**

1. 在 `mountElement` 绑定 `props` 时，判断 `props -> key` 名称是否为事件命名格式： `on+大写字母开头`

2. 使用正则来匹配 `/^on[A-Z]/.test(key)`，如匹配则为当前 `el` 添加事件监听 `addEventListener(eventName, fn)`，否则添加属性 `setAttribute`

3. `addEventListener(eventName, fn)` 中参数 `eventName` 需移除 `on` 且小写，如：`'onClick'.slice(2).toLocaleLowerCase()` -> `addEventListener('click', fn)`
