### PR TITLE
✨第二十二回: 实现组件 props 功能

### DIFF
--- a/example/hellow world/App.js
+++ b/example/hellow world/App.js
@@ -1,6 +1,8 @@
 import { h } from '../../lib/yolo-vue.esm.js'
+import { Foo } from './Foo.js'
 
 export const App = {
+    name: 'App',
     render() {
     window.self = this
     return h(
@@ -14,8 +16,8 @@ export const App = {
             // `Hello ${this.msg}!`
             //`hello world!`
             [
-                h('p', {class: 'red'}, '红色'),
-                h('p', {class: 'green'}, '绿色')
+                h('div',{ id: 'AppId' }, `Hello ${this.msg}!`),
+                h(Foo, { count: 1 }),
             ]
         )
     },

--- a/example/hellow world/Foo.js
+++ b/example/hellow world/Foo.js
@@ -1,0 +1,12 @@
+import { h } from "../../lib/yolo-vue.esm.js"
+
+export const Foo = {
+    name: 'Foo',
+    render() {
+       return h('div', {}, `count is : ${this.count}`)
+    },
+    setup(props) {
+        console.log(`setup props: ${props.count}`)
+        props.count++ // warning
+    }
+}

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -28,12 +28,112 @@ function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
+const extend = Object.assign;
+const isObject = (val) => {
+    return val !== null && typeof (val) === 'object';
+};
 const isOn = (key) => {
     return /^on[A-z]/.test(key);
 };
 const getEventNameByKey = (key) => {
     return key.slice(2).toLocaleLowerCase();
 };
+const hasOwn = (target, key) => Object.prototype.hasOwnProperty.call(target, key);
+
+const targetMap = new Map();
+function trigger(target, key) {
+    // 如果 reactive 对象未使用过 effect，无需 trigger
+    if (targetMap.size > 0) {
+        const depsMap = targetMap.get(target);
+        if (depsMap && depsMap.has(key)) {
+            const dep = depsMap.get(key);
+            triggerEffects(dep);
+        }
+    }
+}
+function triggerEffects(dep) {
+    for (const effect of dep) {
+        if (effect.scheduler) {
+            effect.scheduler();
+        }
+        else {
+            effect.run();
+        }
+    }
+}
+
+const get = createGetter();
+const set = createSetter();
+const readonlyGet = createGetter(true);
+const shallowReadonlyGet = createGetter(true, true);
+function createGetter(isReadonly = false, isShallow = false) {
+    return function get(target, key) {
+        // 判断 isReadonly｜isReactive
+        if (key === ReactiveFlags.IS_REACTIVE) {
+            return !isReadonly;
+        }
+        else if (key === ReactiveFlags.IS_READONLY) {
+            return isReadonly;
+        }
+        const res = Reflect.get(target, key);
+        // 如果是表层响应对象，直接返回
+        if (isShallow) {
+            return res;
+        }
+        // 处理嵌套对象
+        if (isObject(res)) {
+            return isReadonly ? readonly(res) : reactive(res);
+        }
+        return res;
+    };
+}
+function createSetter() {
+    return function set(target, key, value) {
+        const res = Reflect.set(target, key, value);
+        trigger(target, key); // 依赖触发
+        return res;
+    };
+}
+const mutableHandler = {
+    get,
+    set,
+};
+const readonlyHandler = {
+    get: readonlyGet,
+    set: (target, key, value) => {
+        console.warn('Cannot change readonly object');
+        return true;
+    }
+};
+const shallowReadonlyHandler = extend({}, readonlyHandler, {
+    get: shallowReadonlyGet
+});
+
+var ReactiveFlags;
+(function (ReactiveFlags) {
+    ReactiveFlags["IS_REACTIVE"] = "__v__is_reactive";
+    ReactiveFlags["IS_READONLY"] = "__v__is_readonly";
+})(ReactiveFlags || (ReactiveFlags = {}));
+function reactive(raw) {
+    return createActiveObject(raw, mutableHandler);
+}
+function readonly(raw) {
+    return createActiveObject(raw, readonlyHandler);
+}
+function shallowReadonly(raw) {
+    return createActiveObject(raw, shallowReadonlyHandler);
+}
+function createActiveObject(target, baseHandler) {
+    if (!isObject(target)) {
+        console.warn('target is not a object');
+        return target;
+    }
+    return new Proxy(target, baseHandler);
+}
+
+function initProps(instance, rawProps) {
+    instance.props = rawProps || {};
+}
 
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
@@ -42,11 +142,14 @@ const publicPropertiesMap = {
 };
 const publicInstanceProxyHandlers = {
     get({ _: instance }, key) {
-        const { setupState } = instance;
-        if (key in setupState) {
+        const { setupState, props } = instance;
+        if (hasOwn(setupState, key)) {
             return Reflect.get(setupState, key);
         }
-        if (key in publicPropertiesMap) {
+        if (hasOwn(props, key)) {
+            return Reflect.get(props, key);
+        }
+        if (hasOwn(publicPropertiesMap, key)) {
             return Reflect.get(publicPropertiesMap, key)(instance);
         }
     }
@@ -57,41 +160,42 @@ function createComponentInstance(vnode) {
     const component = {
         vnode,
         type: vnode.type,
-        setupState: {}
+        setupState: {},
+        props: {}
     };
     return component;
 }
 // 安装组件
 function setupComponent(instance) {
-    // TODO initProps、initSlots
+    initProps(instance, instance.vnode.props);
+    // TODO initSlots
     // 为 instance 挂载 setupState、render 函数
     setupStatufulComponent(instance);
 }
 // 安装组件状态
 function setupStatufulComponent(instance) {
     const component = instance.type;
-    // 代理组件对象（setupState、$el、$data...）
+    // 代理组件对象（setupState、props、$el、$data...）
     instance.proxy = new Proxy({ _: instance }, publicInstanceProxyHandlers);
     // 处理 setup 函数
     if (component.setup) {
-        const setupResult = component.setup();
+        const setupResult = component.setup(shallowReadonly(instance.props));
         handleSetupResult(instance, setupResult);
     }
 }
 // 处理 setupResult（挂载 setupState）
 function handleSetupResult(instance, setupResult) {
+    // TODO function
+    // object
     if (typeof setupResult === 'object') {
         instance.setupState = setupResult;
-        finishComponentSetup(instance);
     }
-    // TODO function
+    finishComponentSetup(instance);
 }
 // 完成组件按钮（挂载render）
 function finishComponentSetup(instance) {
     const component = instance.type;
-    if (component.render) {
-        instance.render = component.render;
-    }
+    instance.render = component.render;
 }
 
 function render(vnode, container) {

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -26,12 +26,112 @@ function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
+const extend = Object.assign;
+const isObject = (val) => {
+    return val !== null && typeof (val) === 'object';
+};
 const isOn = (key) => {
     return /^on[A-z]/.test(key);
 };
 const getEventNameByKey = (key) => {
     return key.slice(2).toLocaleLowerCase();
 };
+const hasOwn = (target, key) => Object.prototype.hasOwnProperty.call(target, key);
+
+const targetMap = new Map();
+function trigger(target, key) {
+    // 如果 reactive 对象未使用过 effect，无需 trigger
+    if (targetMap.size > 0) {
+        const depsMap = targetMap.get(target);
+        if (depsMap && depsMap.has(key)) {
+            const dep = depsMap.get(key);
+            triggerEffects(dep);
+        }
+    }
+}
+function triggerEffects(dep) {
+    for (const effect of dep) {
+        if (effect.scheduler) {
+            effect.scheduler();
+        }
+        else {
+            effect.run();
+        }
+    }
+}
+
+const get = createGetter();
+const set = createSetter();
+const readonlyGet = createGetter(true);
+const shallowReadonlyGet = createGetter(true, true);
+function createGetter(isReadonly = false, isShallow = false) {
+    return function get(target, key) {
+        // 判断 isReadonly｜isReactive
+        if (key === ReactiveFlags.IS_REACTIVE) {
+            return !isReadonly;
+        }
+        else if (key === ReactiveFlags.IS_READONLY) {
+            return isReadonly;
+        }
+        const res = Reflect.get(target, key);
+        // 如果是表层响应对象，直接返回
+        if (isShallow) {
+            return res;
+        }
+        // 处理嵌套对象
+        if (isObject(res)) {
+            return isReadonly ? readonly(res) : reactive(res);
+        }
+        return res;
+    };
+}
+function createSetter() {
+    return function set(target, key, value) {
+        const res = Reflect.set(target, key, value);
+        trigger(target, key); // 依赖触发
+        return res;
+    };
+}
+const mutableHandler = {
+    get,
+    set,
+};
+const readonlyHandler = {
+    get: readonlyGet,
+    set: (target, key, value) => {
+        console.warn('Cannot change readonly object');
+        return true;
+    }
+};
+const shallowReadonlyHandler = extend({}, readonlyHandler, {
+    get: shallowReadonlyGet
+});
+
+var ReactiveFlags;
+(function (ReactiveFlags) {
+    ReactiveFlags["IS_REACTIVE"] = "__v__is_reactive";
+    ReactiveFlags["IS_READONLY"] = "__v__is_readonly";
+})(ReactiveFlags || (ReactiveFlags = {}));
+function reactive(raw) {
+    return createActiveObject(raw, mutableHandler);
+}
+function readonly(raw) {
+    return createActiveObject(raw, readonlyHandler);
+}
+function shallowReadonly(raw) {
+    return createActiveObject(raw, shallowReadonlyHandler);
+}
+function createActiveObject(target, baseHandler) {
+    if (!isObject(target)) {
+        console.warn('target is not a object');
+        return target;
+    }
+    return new Proxy(target, baseHandler);
+}
+
+function initProps(instance, rawProps) {
+    instance.props = rawProps || {};
+}
 
 const publicPropertiesMap = {
     $el: (i) => i.vnode.el
@@ -40,11 +140,14 @@ const publicPropertiesMap = {
 };
 const publicInstanceProxyHandlers = {
     get({ _: instance }, key) {
-        const { setupState } = instance;
-        if (key in setupState) {
+        const { setupState, props } = instance;
+        if (hasOwn(setupState, key)) {
             return Reflect.get(setupState, key);
         }
-        if (key in publicPropertiesMap) {
+        if (hasOwn(props, key)) {
+            return Reflect.get(props, key);
+        }
+        if (hasOwn(publicPropertiesMap, key)) {
             return Reflect.get(publicPropertiesMap, key)(instance);
         }
     }
@@ -55,41 +158,42 @@ function createComponentInstance(vnode) {
     const component = {
         vnode,
         type: vnode.type,
-        setupState: {}
+        setupState: {},
+        props: {}
     };
     return component;
 }
 // 安装组件
 function setupComponent(instance) {
-    // TODO initProps、initSlots
+    initProps(instance, instance.vnode.props);
+    // TODO initSlots
     // 为 instance 挂载 setupState、render 函数
     setupStatufulComponent(instance);
 }
 // 安装组件状态
 function setupStatufulComponent(instance) {
     const component = instance.type;
-    // 代理组件对象（setupState、$el、$data...）
+    // 代理组件对象（setupState、props、$el、$data...）
     instance.proxy = new Proxy({ _: instance }, publicInstanceProxyHandlers);
     // 处理 setup 函数
     if (component.setup) {
-        const setupResult = component.setup();
+        const setupResult = component.setup(shallowReadonly(instance.props));
         handleSetupResult(instance, setupResult);
     }
 }
 // 处理 setupResult（挂载 setupState）
 function handleSetupResult(instance, setupResult) {
+    // TODO function
+    // object
     if (typeof setupResult === 'object') {
         instance.setupState = setupResult;
-        finishComponentSetup(instance);
     }
-    // TODO function
+    finishComponentSetup(instance);
 }
 // 完成组件按钮（挂载render）
 function finishComponentSetup(instance) {
     const component = instance.type;
-    if (component.render) {
-        instance.render = component.render;
-    }
+    instance.render = component.render;
 }
 
 function render(vnode, container) {

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -1,3 +1,4 @@
+import { isObject } from '../shared'
 import { mutableHandler, readonlyHandler, shallowReadonlyHandler } from './baseHandlers'
 
 export enum ReactiveFlags {
@@ -17,8 +18,12 @@ export function shallowReadonly(raw) {
     return createActiveObject(raw, shallowReadonlyHandler)
 }
 
-export function createActiveObject(raw, baseHandler) {
-    return new Proxy(raw, baseHandler)
+export function createActiveObject(target, baseHandler) {
+    if (!isObject(target)) {
+        console.warn('target is not a object')
+        return target
+    }
+    return new Proxy(target, baseHandler)
 }
 
 export function isReactive (value){

--- a/src/runtime-core/component.ts
+++ b/src/runtime-core/component.ts
@@ -1,3 +1,5 @@
+import { shallowReadonly } from "../reactivity/reactive"
+import { initProps } from "./componentProps"
 import { publicInstanceProxyHandlers } from "./componentPublicInstance"
 
 // 创建组件实例
@@ -5,14 +7,16 @@ export function createComponentInstance(vnode: any) {
     const component = {
         vnode,
         type: vnode.type,
-        setupState: {}
+        setupState: {},
+        props: {}
     }
     return component
 }
 
 // 安装组件
 export function setupComponent(instance) {
-    // TODO initProps、initSlots
+    initProps(instance, instance.vnode.props)
+    // TODO initSlots
     // 为 instance 挂载 setupState、render 函数
     setupStatufulComponent(instance)
 }
@@ -21,29 +25,29 @@ export function setupComponent(instance) {
 export function setupStatufulComponent(instance: any) {
     const component = instance.type
     
-    // 代理组件对象（setupState、$el、$data...）
+    // 代理组件对象（setupState、props、$el、$data...）
     instance.proxy = new Proxy( { _: instance }, publicInstanceProxyHandlers)
 
     // 处理 setup 函数
     if(component.setup) {
-        const setupResult = component.setup()
+        const setupResult = component.setup(shallowReadonly(instance.props))
         handleSetupResult(instance, setupResult)
     }
 }
 
 // 处理 setupResult（挂载 setupState）
 export function handleSetupResult(instance: any, setupResult: any) {
+    // TODO function
+    
+    // object
     if(typeof setupResult === 'object') {
         instance.setupState = setupResult
-        finishComponentSetup(instance)
     }
-    // TODO function
+    finishComponentSetup(instance)
 }
 
 // 完成组件按钮（挂载render）
 export function finishComponentSetup(instance: any) {
     const component = instance.type
-    if(component.render) {
-        instance.render = component.render
-    }
+    instance.render = component.render
 }

--- a/src/runtime-core/componentProps.ts
+++ b/src/runtime-core/componentProps.ts
@@ -1,0 +1,3 @@
+export function initProps(instance, rawProps) {
+    instance.props = rawProps || {}
+}

--- a/src/runtime-core/componentPublicInstance.ts
+++ b/src/runtime-core/componentPublicInstance.ts
@@ -1,3 +1,5 @@
+import { hasOwn } from "../shared"
+
 const publicPropertiesMap = {
     $el: (i)=> i.vnode.el
     // $data
@@ -6,12 +8,15 @@ const publicPropertiesMap = {
 
 export const publicInstanceProxyHandlers = {
     get({ _: instance }, key) {
-        const { setupState } = instance
-        if(key in setupState) {
-            return Reflect.get(setupState,key)
+        const { setupState, props } = instance
+        if (hasOwn(setupState, key)) {
+            return Reflect.get(setupState, key)
         }
-        if (key in publicPropertiesMap) {
-            return Reflect.get(publicPropertiesMap,key)(instance)
+        if (hasOwn(props, key)) {
+            return Reflect.get(props, key)
+        }
+        if (hasOwn(publicPropertiesMap, key)) {
+            return Reflect.get(publicPropertiesMap, key)(instance)
         }
     }
 }

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -15,3 +15,5 @@ export const isOn = (key: string) => {
 export const getEventNameByKey = (key: string) => {
     return key.slice(2).toLocaleLowerCase()
 }
+
+export const hasOwn = (target, key) => Object.prototype.hasOwnProperty.call(target, key)


### PR DESCRIPTION
**实现组件 props 功能**

1. 在 `setupComponent(instance)` 函数中，初步实现 `initProps`：`instance.props = instance.vnode.props || {}`

2. 在 `setupStatefulComponent(instance)` 调用 `setup()` 时，传入 `instance.props`，使得组件可以在 `setup` 中获取 `props` 数据

3. 为了可以在组件的 `render` 中使用 this.xx 来获取组件 `props` 数据，需要修改代理 `instance.proxy` 对象的 `get` 函数，增加从 `instance.props` 中获取数据逻辑：`if (key in props) { return props[key] }`

4. 遵循组件单向数据流原则，组件的 `props` 对象应为只读对象，即调用 `setup(instance.props)` 时， 需用 `shallowReadonly` 包裹 `props` ，如：`setup(shallowReadony(instance.props))`