### PR TITLE
✨第二十四回: 实现组件 slots 功能

### DIFF
--- a/example/component-slots/App.js
+++ b/example/component-slots/App.js
@@ -1,0 +1,40 @@
+import { h } from '../../lib/yolo-vue.esm.js'
+import { Foo } from './Foo.js'
+
+export const App = {
+    name: 'App',
+    render() {
+        const slots = {
+            default: () => h('p', {}, 'fooSlot - defualt'),
+            header: ({row, title}) => 
+                [
+                    h('p', {}, 'fooSlot - header'), 
+                    h('p', {}, `fooSlot - header - scoped: ${row.age} ${title}`)
+                ],
+            footer: () => h('p', {}, 'fooSlot - footer')
+        }
+        return h('div', { class: 'App' }, 
+            [
+                h('p', {}, 'App'), 
+                h(Foo, {}, slots)
+            ]
+        )
+        // 等同于 template：
+        // <div class="App">
+        //    <p>App</p>
+        //    <Foo>
+        //        <p>fooSlot - defualt</p>
+        //        <template #header={row, title}>
+        //            <p>fooSlot - header</p>
+        //            <p>fooSlot - header - scoped: {{ row.age }} {{ title }}</p>
+        //        </template>
+        //        <template v-slot:footer>
+        //            <p>fooSlot - footer</p>
+        //        </template>
+        //    </Foo>
+        // </div>
+    },
+    setup() {
+       
+    }
+}

--- a/example/component-slots/Foo.js
+++ b/example/component-slots/Foo.js
@@ -1,0 +1,25 @@
+import { h, renderSlots } from "../../lib/yolo-vue.esm.js"
+
+export const Foo = {
+    name: 'Foo',
+    render() {
+        return h(
+            'div', { class: 'Foo' }, 
+            [
+                renderSlots(this.$slots, 'header', {row: { age: 18 }, title: '插槽数据'}), 
+                h('p', {}, 'Foo'), 
+                renderSlots(this.$slots, 'default'),
+                renderSlots(this.$slots, 'footer')
+            ]
+        )
+        // 等同于 template：
+        // <div class="Foo">
+        //     <slot name="header" :row="{age: 18}" title="插槽数据"></slot>
+        //     <p>Foo</p>
+        //     <slot></slot>
+        //     <slot name="footer"></slot>
+        // </div>
+    },
+    setup() {
+    }
+}

--- a/example/component-slots/index.html
+++ b/example/component-slots/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hello world</title>
+    <style>
+        .red {
+             color: red;
+        }
+        .green {
+            color: greenyellow;
+        }
+    </style>
+</head>
+<body>
+    <div id="app"></div>
+    <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/example/component-slots/main.js
+++ b/example/component-slots/main.js
@@ -1,0 +1,4 @@
+import { createApp } from '../../lib/yolo-vue.esm.js'
+import { App } from './App.js'
+
+createApp(App).mount('#app')

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -6,6 +6,7 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
     ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
     ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
 function createVNode(type, props, children) {
@@ -21,6 +22,12 @@ function createVNode(type, props, children) {
     }
     else if (typeof children === 'object') {
         vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
+    }
+    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
+    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        if (typeof vnode.children === 'object') {
+            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
+        }
     }
     return vnode;
 }
@@ -160,7 +167,8 @@ function initProps(instance, rawProps) {
 }
 
 const publicPropertiesMap = {
-    $el: (i) => i.vnode.el
+    $el: (i) => i.vnode.el,
+    $slots: (i) => i.slots
     // $data
     // ...
 };
@@ -179,6 +187,23 @@ const publicInstanceProxyHandlers = {
     }
 };
 
+function initSlots(instance, children) {
+    const { vnode } = instance;
+    // vnode.shapeFlag 标记为 SLOT_CHILDREN 时，才执行绑定 slots 逻辑
+    if (vnode.shapeFlag & ShapeFlags.SLOT_CHILDREN) {
+        normalizeObjectSlots(children, instance.slots);
+    }
+}
+function normalizeObjectSlots(children, slots) {
+    for (const key in children) {
+        const value = children[key];
+        slots[key] = (props) => normalizeSlotValue(value(props));
+    }
+}
+function normalizeSlotValue(value) {
+    return Array.isArray(value) ? value : [value];
+}
+
 // 创建组件实例
 function createComponentInstance(vnode) {
     const component = {
@@ -186,6 +211,7 @@ function createComponentInstance(vnode) {
         type: vnode.type,
         setupState: {},
         props: {},
+        slots: {},
         emit: () => { }
     };
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -195,8 +221,7 @@ function createComponentInstance(vnode) {
 // 安装组件
 function setupComponent(instance) {
     initProps(instance, instance.vnode.props);
-    // TODO initSlots
-    // 为 instance 挂载 setupState、render 函数
+    initSlots(instance, instance.vnode.children);
     setupStatufulComponent(instance);
 }
 // 安装组件状态
@@ -307,5 +332,15 @@ function h(type, props, children) {
     return createVNode(type, props, children);
 }
 
+function renderSlots(slots, name, props) {
+    const slot = slots[name];
+    if (slot) {
+        if (typeof slot === 'function') {
+            return createVNode('div', {}, slot(props));
+        }
+    }
+}
+
 exports.createApp = createApp;
 exports.h = h;
+exports.renderSlots = renderSlots;

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -4,6 +4,7 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
     ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
     ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
 function createVNode(type, props, children) {
@@ -19,6 +20,12 @@ function createVNode(type, props, children) {
     }
     else if (typeof children === 'object') {
         vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
+    }
+    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
+    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        if (typeof vnode.children === 'object') {
+            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
+        }
     }
     return vnode;
 }
@@ -158,7 +165,8 @@ function initProps(instance, rawProps) {
 }
 
 const publicPropertiesMap = {
-    $el: (i) => i.vnode.el
+    $el: (i) => i.vnode.el,
+    $slots: (i) => i.slots
     // $data
     // ...
 };
@@ -177,6 +185,23 @@ const publicInstanceProxyHandlers = {
     }
 };
 
+function initSlots(instance, children) {
+    const { vnode } = instance;
+    // vnode.shapeFlag 标记为 SLOT_CHILDREN 时，才执行绑定 slots 逻辑
+    if (vnode.shapeFlag & ShapeFlags.SLOT_CHILDREN) {
+        normalizeObjectSlots(children, instance.slots);
+    }
+}
+function normalizeObjectSlots(children, slots) {
+    for (const key in children) {
+        const value = children[key];
+        slots[key] = (props) => normalizeSlotValue(value(props));
+    }
+}
+function normalizeSlotValue(value) {
+    return Array.isArray(value) ? value : [value];
+}
+
 // 创建组件实例
 function createComponentInstance(vnode) {
     const component = {
@@ -184,6 +209,7 @@ function createComponentInstance(vnode) {
         type: vnode.type,
         setupState: {},
         props: {},
+        slots: {},
         emit: () => { }
     };
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -193,8 +219,7 @@ function createComponentInstance(vnode) {
 // 安装组件
 function setupComponent(instance) {
     initProps(instance, instance.vnode.props);
-    // TODO initSlots
-    // 为 instance 挂载 setupState、render 函数
+    initSlots(instance, instance.vnode.children);
     setupStatufulComponent(instance);
 }
 // 安装组件状态
@@ -305,4 +330,13 @@ function h(type, props, children) {
     return createVNode(type, props, children);
 }
 
-export { createApp, h };
+function renderSlots(slots, name, props) {
+    const slot = slots[name];
+    if (slot) {
+        if (typeof slot === 'function') {
+            return createVNode('div', {}, slot(props));
+        }
+    }
+}
+
+export { createApp, h, renderSlots };

--- a/src/runtime-core/component.ts
+++ b/src/runtime-core/component.ts
@@ -2,6 +2,7 @@ import { shallowReadonly } from "../reactivity/reactive"
 import { emit } from "./componentEmit"
 import { initProps } from "./componentProps"
 import { publicInstanceProxyHandlers } from "./componentPublicInstance"
+import { initSlots } from "./componentSlots"
 
 // 创建组件实例
 export function createComponentInstance(vnode: any) {
@@ -10,6 +11,7 @@ export function createComponentInstance(vnode: any) {
         type: vnode.type,
         setupState: {},
         props: {},
+        slots: {},
         emit: () => {}
     }
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -20,8 +22,7 @@ export function createComponentInstance(vnode: any) {
 // 安装组件
 export function setupComponent(instance) {
     initProps(instance, instance.vnode.props)
-    // TODO initSlots
-    // 为 instance 挂载 setupState、render 函数
+    initSlots(instance, instance.vnode.children)
     setupStatufulComponent(instance)
 }
 
@@ -55,3 +56,4 @@ export function finishComponentSetup(instance: any) {
     const component = instance.type
     instance.render = component.render
 }
+

--- a/src/runtime-core/componentPublicInstance.ts
+++ b/src/runtime-core/componentPublicInstance.ts
@@ -1,7 +1,8 @@
 import { hasOwn } from "../shared"
 
 const publicPropertiesMap = {
-    $el: (i)=> i.vnode.el
+    $el: (i) => i.vnode.el,
+    $slots: (i) => i.slots
     // $data
     // ...
 }

--- a/src/runtime-core/componentSlots.ts
+++ b/src/runtime-core/componentSlots.ts
@@ -1,0 +1,20 @@
+import { ShapeFlags } from "../shared/ShapeFlags"
+
+export function initSlots(instance: any, children: any) {
+    const { vnode } = instance
+    // vnode.shapeFlag 标记为 SLOT_CHILDREN 时，才执行绑定 slots 逻辑
+    if( vnode.shapeFlag & ShapeFlags.SLOT_CHILDREN) {
+        normalizeObjectSlots(children, instance.slots)
+    }
+}
+
+function normalizeObjectSlots(children, slots) {
+    for (const key in children) {
+        const value = children[key]
+        slots[key] = (props) => normalizeSlotValue(value(props))
+    }
+}
+
+function normalizeSlotValue(value) {
+    return Array.isArray(value) ? value : [value]
+}

--- a/src/runtime-core/helpers/renderSlots.ts
+++ b/src/runtime-core/helpers/renderSlots.ts
@@ -1,0 +1,10 @@
+import { createVNode } from '../vnode'
+
+export function renderSlots(slots, name, props) {
+    const slot = slots[name]
+    if(slot) {
+        if (typeof slot === 'function') {
+            return createVNode('div', {}, slot(props))
+        }
+    }
+}

--- a/src/runtime-core/index.ts
+++ b/src/runtime-core/index.ts
@@ -1,2 +1,3 @@
 export { createApp } from "./createApp";
 export { h } from './h'
+export { renderSlots } from './helpers/renderSlots'

--- a/src/runtime-core/vnode.ts
+++ b/src/runtime-core/vnode.ts
@@ -9,10 +9,17 @@ export function createVNode(type, props?, children?) {
         el: null
     }
 
-    if(typeof children === 'string') {
+    if (typeof children === 'string') {
         vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN
-    } else if(typeof children === 'object') {
+    } else if (typeof children === 'object') {
         vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN
+    }
+
+    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
+    if(vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        if(typeof vnode.children === 'object') {
+            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN
+        }
     }
 
     return vnode

--- a/src/shared/ShapeFlags.ts
+++ b/src/shared/ShapeFlags.ts
@@ -2,5 +2,6 @@ export enum ShapeFlags {
     ELEMENT = 1,
     STATEFUL_COMPONENT = 1 << 1,
     TEXT_CHILDREN = 1 << 2,
-    ARRAY_CHILREN = 1 << 3
+    ARRAY_CHILREN = 1 << 3,
+    SLOT_CHILDREN = 1 << 4
 }


### PR DESCRIPTION
**实现组件 slots 功能**

1. `initSlots` 初始化插槽

    1.1. 判断 `vnode.shapeFlag` 标志包含  `ShapeFlags.SLOT_CHILDREN` 则绑定插槽，
    1.2. 存：将 `children` 存至当前组件实例 `slots`
    1.3. 取：调用 `this.$slots` 时，利用组件代理 `proxy` 中 `get` 判断 `key` 值，获取当前组件实例 `instance.slots`

2. `renderSlots` 函数

    2.1. 在需要插入的位置调用，将返回对应插槽内的 `vnode`
    2.2. 根据 `name` 匹配获取 `slots` 中的插槽 `slot`，执行 `slot` 函数并传入 `props`
    2.3. 接收参数：
    `slots`：this.$slots
    `name`：插槽名称
    `props`：插槽参数

3. `slots` 插槽以 `object: { function }` 形式在组件 `children` 中绑定，如：

**父组件：**
```javascript
render() {
  const slots = {
    default: () => h('p', {}, 'fooSlot - defualt'),
    header: (props) => h('p', {}, '具名插槽作用域：'+props)
  }
  return h('div', { class: 'App' }, 
  [
      h('p', {}, 'App'), 
      h('Foo', {}, slots)
  ]
}
```
等同于 template：
```html
 <div class="App">
   <p>App</p>
   <Foo>
       <p>fooSlot - defualt</p>
       <template #header={name}>
           <p>具名插槽作用域：{{ name }}</p>
       </template>
   </Foo>
</div>
```
**子组件**
```javascript
render() {
  return h(
   'div', 
    { class: 'Foo' }, 
    [
        renderSlots(this.$slots, 'header', { name: leo }), 
        h('p', {}, 'foo - p'), 
        renderSlots(this.$slots, 'default'),
    ]
  )
}
```
等同于 template：
```html
 <div class="Foo">
     <slot name="header" name="leo"></slot>
     <p>foo - p</p>
     <slot></slot>
     <slot name="footer"></slot>
 </div>
```