### PR TITLE
✨第二十五回: 实现 Fragment 和 Text 类型节点

### DIFF
--- a/example/component-slots/App.js
+++ b/example/component-slots/App.js
@@ -1,4 +1,4 @@
-import { h } from '../../lib/yolo-vue.esm.js'
+import { h, createTextVNode } from '../../lib/yolo-vue.esm.js'
 import { Foo } from './Foo.js'
 
 export const App = {
@@ -9,7 +9,8 @@ export const App = {
             header: ({row, title}) => 
                 [
                     h('p', {}, 'fooSlot - header'), 
-                    h('p', {}, `fooSlot - header - scoped: ${row.age} ${title}`)
+                    h('p', {}, `fooSlot - header - scoped: ${row.age} ${title}`),
+                    createTextVNode('文本节点内容')
                 ],
             footer: () => h('p', {}, 'fooSlot - footer')
         }

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -9,6 +9,8 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
+const Fragment = Symbol('Fragment');
+const Text = Symbol('Text');
 function createVNode(type, props, children) {
     const vnode = {
         type,
@@ -30,6 +32,9 @@ function createVNode(type, props, children) {
         }
     }
     return vnode;
+}
+function createTextVNode(text) {
+    return createVNode(Text, {}, text);
 }
 function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
@@ -253,16 +258,37 @@ function finishComponentSetup(instance) {
 function render(vnode, container) {
     patch(vnode, container);
 }
+// 判断 vnode 类型，区分处理
 function patch(vnode, container) {
-    const { shapeFlag } = vnode;
-    if (shapeFlag & ShapeFlags.ELEMENT) {
-        // 判断 vnode 类型为 ELEMENT：调用 processElement
-        processElement(vnode, container);
+    const { type, shapeFlag } = vnode;
+    switch (type) {
+        case Fragment:
+            processFragment(vnode, container);
+            break;
+        case Text:
+            processText(vnode, container);
+            break;
+        default:
+            if (shapeFlag & ShapeFlags.ELEMENT) {
+                // 判断 vnode 类型为 ELEMENT：调用 processElement
+                processElement(vnode, container);
+            }
+            else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                processComponent(vnode, container);
+            }
+            break;
     }
-    else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-        processComponent(vnode, container);
-    }
+}
+// 处理 Fragment
+function processFragment(vnode, container) {
+    mountChildren(vnode, container);
+}
+// 处理 Text
+function processText(vnode, container) {
+    const { children } = vnode;
+    const el = vnode.el = document.createTextNode(children);
+    container.append(el);
 }
 // 处理 Element
 function processElement(vnode, container) {
@@ -336,11 +362,12 @@ function renderSlots(slots, name, props) {
     const slot = slots[name];
     if (slot) {
         if (typeof slot === 'function') {
-            return createVNode('div', {}, slot(props));
+            return createVNode(Fragment, {}, slot(props));
         }
     }
 }
 
 exports.createApp = createApp;
+exports.createTextVNode = createTextVNode;
 exports.h = h;
 exports.renderSlots = renderSlots;

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -7,6 +7,8 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
+const Fragment = Symbol('Fragment');
+const Text = Symbol('Text');
 function createVNode(type, props, children) {
     const vnode = {
         type,
@@ -28,6 +30,9 @@ function createVNode(type, props, children) {
         }
     }
     return vnode;
+}
+function createTextVNode(text) {
+    return createVNode(Text, {}, text);
 }
 function getShapeFlag(type) {
     return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
@@ -251,16 +256,37 @@ function finishComponentSetup(instance) {
 function render(vnode, container) {
     patch(vnode, container);
 }
+// 判断 vnode 类型，区分处理
 function patch(vnode, container) {
-    const { shapeFlag } = vnode;
-    if (shapeFlag & ShapeFlags.ELEMENT) {
-        // 判断 vnode 类型为 ELEMENT：调用 processElement
-        processElement(vnode, container);
+    const { type, shapeFlag } = vnode;
+    switch (type) {
+        case Fragment:
+            processFragment(vnode, container);
+            break;
+        case Text:
+            processText(vnode, container);
+            break;
+        default:
+            if (shapeFlag & ShapeFlags.ELEMENT) {
+                // 判断 vnode 类型为 ELEMENT：调用 processElement
+                processElement(vnode, container);
+            }
+            else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                processComponent(vnode, container);
+            }
+            break;
     }
-    else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-        processComponent(vnode, container);
-    }
+}
+// 处理 Fragment
+function processFragment(vnode, container) {
+    mountChildren(vnode, container);
+}
+// 处理 Text
+function processText(vnode, container) {
+    const { children } = vnode;
+    const el = vnode.el = document.createTextNode(children);
+    container.append(el);
 }
 // 处理 Element
 function processElement(vnode, container) {
@@ -334,9 +360,9 @@ function renderSlots(slots, name, props) {
     const slot = slots[name];
     if (slot) {
         if (typeof slot === 'function') {
-            return createVNode('div', {}, slot(props));
+            return createVNode(Fragment, {}, slot(props));
         }
     }
 }
 
-export { createApp, h, renderSlots };
+export { createApp, createTextVNode, h, renderSlots };

--- a/src/runtime-core/componentSlots.ts
+++ b/src/runtime-core/componentSlots.ts
@@ -1,6 +1,7 @@
 import { ShapeFlags } from "../shared/ShapeFlags"
 
 export function initSlots(instance: any, children: any) {
+
     const { vnode } = instance
     // vnode.shapeFlag 标记为 SLOT_CHILDREN 时，才执行绑定 slots 逻辑
     if( vnode.shapeFlag & ShapeFlags.SLOT_CHILDREN) {

--- a/src/runtime-core/helpers/renderSlots.ts
+++ b/src/runtime-core/helpers/renderSlots.ts
@@ -1,10 +1,11 @@
-import { createVNode } from '../vnode'
+import { Fragment, createVNode } from '../vnode'
+
 
 export function renderSlots(slots, name, props) {
     const slot = slots[name]
     if(slot) {
         if (typeof slot === 'function') {
-            return createVNode('div', {}, slot(props))
+            return createVNode(Fragment, {}, slot(props))
         }
     }
 }

--- a/src/runtime-core/index.ts
+++ b/src/runtime-core/index.ts
@@ -1,3 +1,4 @@
 export { createApp } from "./createApp";
 export { h } from './h'
 export { renderSlots } from './helpers/renderSlots'
+export { createTextVNode } from './vnode'

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -1,20 +1,45 @@
 import { ShapeFlags } from "../shared/ShapeFlags"
 import { getEventNameByKey, isObject, isOn } from "../shared/index"
 import { createComponentInstance, setupComponent } from "./component"
+import { Fragment, Text } from "./vnode"
 
 export function render(vnode, container) {
     patch(vnode, container)
 }
 
+// 判断 vnode 类型，区分处理
 function patch(vnode, container) {
-    const { shapeFlag } = vnode
-    if (shapeFlag & ShapeFlags.ELEMENT) {
-        // 判断 vnode 类型为 ELEMENT：调用 processElement
-        processElement(vnode, container)
-    } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-        // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-        processComponent(vnode, container)
+    const { type, shapeFlag } = vnode
+    switch (type) {
+        case Fragment:
+            processFragment(vnode, container)
+            break;
+        case Text:
+            processText(vnode, container)
+            break;
+        default:
+            if (shapeFlag & ShapeFlags.ELEMENT) {
+                // 判断 vnode 类型为 ELEMENT：调用 processElement
+                processElement(vnode, container)
+            } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                processComponent(vnode, container)
+            }
+            break;
     }
+  
+}
+
+// 处理 Fragment
+function processFragment(vnode: any, container: any) {
+    mountChildren(vnode, container)
+}
+
+// 处理 Text
+function processText(vnode: any, container: any) {
+    const { children } = vnode
+    const el = vnode.el = document.createTextNode(children)
+    container.append(el)
 }
 
 // 处理 Element

--- a/src/runtime-core/vnode.ts
+++ b/src/runtime-core/vnode.ts
@@ -1,4 +1,6 @@
 import { ShapeFlags } from "../shared/ShapeFlags";
+export const Fragment = Symbol('Fragment')
+export const Text = Symbol('Text')
 
 export function createVNode(type, props?, children?) {
     const vnode = {
@@ -23,6 +25,10 @@ export function createVNode(type, props?, children?) {
     }
 
     return vnode
+}
+
+export function createTextVNode(text: string) {
+    return createVNode(Text, {}, text)
 }
 
 export function getShapeFlag(type) {


### PR DESCRIPTION
**实现 Fragment 和 Text 类型节点**

**1. Fragment**

在 [第二十四回: 实现组件 slots 功能](https://github.com/liujunleo/yolo-vue3/pull/18) 中，已经实现了组件的 `slots` 功能：
在 `helpers -> renderSlots` 处理插槽内容时， 为了使 `children` 数组能正确传入 `h` 函数（`h` 函数只能嵌套 `vnode` 类型的 `children`），将 `children` 放入了新建 `h` 函数 `type` 为 `'div'` 的 `vnode` 下，这样导致插槽渲染出来的结果，会多出来一层 `div`

所以需要实现一个特殊的组件 `Fragment` ，使其不会产生额外的 `DOM` 节点：

1. 声明类型为 `Fragment` 的 `Symbol('Fragment')`
2. `helpers -> renderSlots` 中 `createVNode` 中 `type` 参数 `'div'` 替换为 `Fragment`
3. 在 `patch` 中判断 `vnode` 的 `type` 为 `Fragment` ，则进入 `processFragment`  只处理其 `children`，调用已有函数 `mountChildren`


**2. Text**

1. 声明类型为 `Text` 的 `Symbol('Text')`
2. 在 `h` 函数中需要传入纯文本时，需要传入 `vnode`，使用 `createTextVNode` 函数，处理纯文本的节点，接收 `text` 并创建返回类型为 `Text` 的 `vnode`
3. 在 `patch` 中判断 `vnode` 的 `type` 为 `Text` ，则进入 `processText` 新建原生节点 `createTextNode(children)`
4. 保存此节点至 `node.e`l 并插入 `contaienr` 父容器中