### PR TITLE
✨第二十八回: 实现自定义渲染器 custom renderer

### DIFF
--- a/example/custom-renderer/App.js
+++ b/example/custom-renderer/App.js
@@ -1,0 +1,16 @@
+import { h } from '../../lib/yolo-vue.esm.js'
+
+export const App = {
+    name: 'App',
+    setup() {
+        return {
+            x: 100,
+            y: 100,
+        }
+    },
+    render() {
+        return h('rect',{x: this.x, y: this.y}, [
+            h('circle',{x: 50, y: 50})
+        ])
+    }
+}

--- a/example/custom-renderer/index.html
+++ b/example/custom-renderer/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hello world</title>
+    <style>
+        .red {
+             color: red;
+        }
+        .green {
+            color: greenyellow;
+        }
+    </style>
+    <script src="https://pixijs.download/release/pixi.js"></script>
+</head>
+<body>
+    <div id="app"></div>
+    <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/example/custom-renderer/main.js
+++ b/example/custom-renderer/main.js
@@ -1,0 +1,37 @@
+import { createRenderer } from '../../lib/yolo-vue.esm.js'
+import { App } from './App.js'
+
+const game = new PIXI.Application({
+    width: 200,
+    height: 200
+})
+
+document.body.append(game.view)
+ 
+
+const renderer = createRenderer({
+    createElement(type) {
+        if(type === 'rect') {
+            const rect = new PIXI.Graphics()
+            rect.beginFill(0xff000)
+            rect.drawRect(-50, -50, 100, 100)
+            rect.endFill()
+            return rect
+        }
+        if(type === 'circle') {
+            const circle = new PIXI.Graphics()
+            circle.beginFill(0xff0000)
+            circle.drawCircle(-50, -50, 25)
+            circle.endFill()
+            return circle
+        }
+    },
+    patchProp(el, key, val) {
+        el[key] = val
+    },
+    insert(el, parent) {
+        parent.addChild(el)
+    }
+})
+
+renderer.createApp(App).mount(game.stage)

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -9,37 +9,6 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
-const Fragment = Symbol('Fragment');
-const Text = Symbol('Text');
-function createVNode(type, props, children) {
-    const vnode = {
-        type,
-        props,
-        children,
-        shapeFlag: getShapeFlag(type),
-        el: null
-    };
-    if (typeof children === 'string') {
-        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
-    }
-    else if (typeof children === 'object') {
-        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
-    }
-    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
-    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-        if (typeof vnode.children === 'object') {
-            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
-        }
-    }
-    return vnode;
-}
-function createTextVNode(text) {
-    return createVNode(Text, {}, text);
-}
-function getShapeFlag(type) {
-    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
-}
-
 const extend = Object.assign;
 const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
@@ -267,102 +236,137 @@ function setCurrentInstance(instance) {
     currentInstance = instance;
 }
 
-function render(vnode, container) {
-    patch(vnode, container, null);
-}
-// 判断 vnode 类型，区分处理
-function patch(vnode, container, parentComponent) {
-    const { type, shapeFlag } = vnode;
-    switch (type) {
-        case Fragment:
-            processFragment(vnode, container, parentComponent);
-            break;
-        case Text:
-            processText(vnode, container);
-            break;
-        default:
-            if (shapeFlag & ShapeFlags.ELEMENT) {
-                // 判断 vnode 类型为 ELEMENT：调用 processElement
-                processElement(vnode, container, parentComponent);
-            }
-            else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                processComponent(vnode, container, parentComponent);
-            }
-            break;
+const Fragment = Symbol('Fragment');
+const Text = Symbol('Text');
+function createVNode(type, props, children) {
+    const vnode = {
+        type,
+        props,
+        children,
+        shapeFlag: getShapeFlag(type),
+        el: null
+    };
+    if (typeof children === 'string') {
+        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
     }
-}
-// 处理 Fragment
-function processFragment(vnode, container, parentComponent) {
-    mountChildren(vnode, container, parentComponent);
-}
-// 处理 Text
-function processText(vnode, container) {
-    const { children } = vnode;
-    const el = vnode.el = document.createTextNode(children);
-    container.append(el);
-}
-// 处理 Element
-function processElement(vnode, container, parentComponent) {
-    mountElement(vnode, container, parentComponent);
-}
-// 挂载 Element
-function mountElement(vnode, container, parentComponent) {
-    // create el & save el to vnode
-    const el = (vnode.el = document.createElement(vnode.type));
-    // children
-    const { children, shapeFlag } = vnode;
-    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
-        el.textContent = children;
+    else if (typeof children === 'object') {
+        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
     }
-    else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
-        // handle multiple childrens
-        mountChildren(vnode, el, parentComponent);
-    }
-    // props
-    const { props } = vnode;
-    for (const key in props) {
-        if (isOn(key)) {
-            el.addEventListener(getEventNameByKey(key), props[key]);
-        }
-        else {
-            el.setAttribute(key, props[key]);
+    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
+    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        if (typeof vnode.children === 'object') {
+            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
         }
     }
-    // el append to container
-    container.append(el);
+    return vnode;
 }
-// 挂载 children 数组，循环调用 patch
-function mountChildren(vnode, container, parentComponent) {
-    vnode.children.forEach(v => {
-        patch(v, container, parentComponent);
-    });
+function createTextVNode(text) {
+    return createVNode(Text, {}, text);
 }
-// 处理组件
-function processComponent(vnode, container, parentComponent) {
-    mountComponent(vnode, container, parentComponent);
-}
-// 挂载组件
-function mountComponent(initialVNode, container, parentComponent) {
-    const instance = createComponentInstance(initialVNode, parentComponent);
-    setupComponent(instance);
-    setupRenderEffect(instance, initialVNode, container);
-}
-// 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, initialVNode, container) {
-    const { proxy } = instance;
-    const subTree = instance.render.call(proxy);
-    patch(subTree, container, instance);
-    initialVNode.el = subTree.el;
+function getShapeFlag(type) {
+    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
-function createApp(rootComponent) {
-    return {
-        mount(rootContainer) {
-            const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer;
-            const vnode = createVNode(rootComponent);
-            render(vnode, container);
+function createAppApi(render) {
+    return function createApp(rootComponent) {
+        return {
+            mount(rootContainer) {
+                const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer;
+                const vnode = createVNode(rootComponent);
+                render(vnode, container);
+            }
+        };
+    };
+}
+
+function createRenderer(options) {
+    const { createElement, patchProp, insert } = options;
+    function render(vnode, container) {
+        patch(vnode, container, null);
+    }
+    // 判断 vnode 类型，区分处理
+    function patch(vnode, container, parentComponent) {
+        const { type, shapeFlag } = vnode;
+        switch (type) {
+            case Fragment:
+                processFragment(vnode, container, parentComponent);
+                break;
+            case Text:
+                processText(vnode, container);
+                break;
+            default:
+                if (shapeFlag & ShapeFlags.ELEMENT) {
+                    // 判断 vnode 类型为 ELEMENT：调用 processElement
+                    processElement(vnode, container, parentComponent);
+                }
+                else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                    // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                    processComponent(vnode, container, parentComponent);
+                }
+                break;
         }
+    }
+    // 处理 Fragment
+    function processFragment(vnode, container, parentComponent) {
+        mountChildren(vnode, container, parentComponent);
+    }
+    // 处理 Text
+    function processText(vnode, container) {
+        const { children } = vnode;
+        const el = vnode.el = document.createTextNode(children);
+        container.append(el);
+    }
+    // 处理 Element
+    function processElement(vnode, container, parentComponent) {
+        mountElement(vnode, container, parentComponent);
+    }
+    // 挂载 Element
+    function mountElement(vnode, container, parentComponent) {
+        // create el & save el to vnode
+        const el = (vnode.el = createElement(vnode.type));
+        // children
+        const { children, shapeFlag } = vnode;
+        if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
+            el.textContent = children;
+        }
+        else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
+            // handle multiple childrens
+            mountChildren(vnode, el, parentComponent);
+        }
+        // props
+        const { props } = vnode;
+        for (const key in props) {
+            const val = props[key];
+            patchProp(el, key, val);
+        }
+        // el append to container
+        insert(el, container);
+    }
+    // 挂载 children 数组，循环调用 patch
+    function mountChildren(vnode, container, parentComponent) {
+        vnode.children.forEach(v => {
+            patch(v, container, parentComponent);
+        });
+    }
+    // 处理组件
+    function processComponent(vnode, container, parentComponent) {
+        mountComponent(vnode, container, parentComponent);
+    }
+    // 挂载组件
+    function mountComponent(initialVNode, container, parentComponent) {
+        const instance = createComponentInstance(initialVNode, parentComponent);
+        setupComponent(instance);
+        setupRenderEffect(instance, initialVNode, container);
+    }
+    // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
+    function setupRenderEffect(instance, initialVNode, container) {
+        const { proxy } = instance;
+        const subTree = instance.render.call(proxy);
+        patch(subTree, container, instance);
+        initialVNode.el = subTree.el;
+    }
+    return {
+        createApp: createAppApi(render)
     };
 }
 
@@ -403,7 +407,27 @@ function inject(key) {
     }
 }
 
+function createElement(type) {
+    return document.createElement(type);
+}
+function patchProp(el, key, value) {
+    if (isOn(key)) {
+        el.addEventListener(getEventNameByKey(key), value);
+    }
+    else {
+        el.setAttribute(key, value);
+    }
+}
+function insert(el, parent) {
+    parent.append(el);
+}
+const renderer = createRenderer({ createElement, patchProp, insert });
+function createApp(...args) {
+    return renderer.createApp(...args);
+}
+
 exports.createApp = createApp;
+exports.createRenderer = createRenderer;
 exports.createTextVNode = createTextVNode;
 exports.getCurrentInstance = getCurrentInstance;
 exports.h = h;

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -7,37 +7,6 @@ var ShapeFlags;
     ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
 })(ShapeFlags || (ShapeFlags = {}));
 
-const Fragment = Symbol('Fragment');
-const Text = Symbol('Text');
-function createVNode(type, props, children) {
-    const vnode = {
-        type,
-        props,
-        children,
-        shapeFlag: getShapeFlag(type),
-        el: null
-    };
-    if (typeof children === 'string') {
-        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
-    }
-    else if (typeof children === 'object') {
-        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
-    }
-    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
-    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-        if (typeof vnode.children === 'object') {
-            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
-        }
-    }
-    return vnode;
-}
-function createTextVNode(text) {
-    return createVNode(Text, {}, text);
-}
-function getShapeFlag(type) {
-    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
-}
-
 const extend = Object.assign;
 const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
@@ -265,102 +234,137 @@ function setCurrentInstance(instance) {
     currentInstance = instance;
 }
 
-function render(vnode, container) {
-    patch(vnode, container, null);
-}
-// 判断 vnode 类型，区分处理
-function patch(vnode, container, parentComponent) {
-    const { type, shapeFlag } = vnode;
-    switch (type) {
-        case Fragment:
-            processFragment(vnode, container, parentComponent);
-            break;
-        case Text:
-            processText(vnode, container);
-            break;
-        default:
-            if (shapeFlag & ShapeFlags.ELEMENT) {
-                // 判断 vnode 类型为 ELEMENT：调用 processElement
-                processElement(vnode, container, parentComponent);
-            }
-            else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                processComponent(vnode, container, parentComponent);
-            }
-            break;
+const Fragment = Symbol('Fragment');
+const Text = Symbol('Text');
+function createVNode(type, props, children) {
+    const vnode = {
+        type,
+        props,
+        children,
+        shapeFlag: getShapeFlag(type),
+        el: null
+    };
+    if (typeof children === 'string') {
+        vnode.shapeFlag |= ShapeFlags.TEXT_CHILDREN;
     }
-}
-// 处理 Fragment
-function processFragment(vnode, container, parentComponent) {
-    mountChildren(vnode, container, parentComponent);
-}
-// 处理 Text
-function processText(vnode, container) {
-    const { children } = vnode;
-    const el = vnode.el = document.createTextNode(children);
-    container.append(el);
-}
-// 处理 Element
-function processElement(vnode, container, parentComponent) {
-    mountElement(vnode, container, parentComponent);
-}
-// 挂载 Element
-function mountElement(vnode, container, parentComponent) {
-    // create el & save el to vnode
-    const el = (vnode.el = document.createElement(vnode.type));
-    // children
-    const { children, shapeFlag } = vnode;
-    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
-        el.textContent = children;
+    else if (typeof children === 'object') {
+        vnode.shapeFlag |= ShapeFlags.ARRAY_CHILREN;
     }
-    else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
-        // handle multiple childrens
-        mountChildren(vnode, el, parentComponent);
-    }
-    // props
-    const { props } = vnode;
-    for (const key in props) {
-        if (isOn(key)) {
-            el.addEventListener(getEventNameByKey(key), props[key]);
-        }
-        else {
-            el.setAttribute(key, props[key]);
+    // 如果当前 vnode，为组件且 children 为 object，设置 shapeFlag 为 SLOT_CHILDREN 标记
+    if (vnode.shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+        if (typeof vnode.children === 'object') {
+            vnode.shapeFlag |= ShapeFlags.SLOT_CHILDREN;
         }
     }
-    // el append to container
-    container.append(el);
+    return vnode;
 }
-// 挂载 children 数组，循环调用 patch
-function mountChildren(vnode, container, parentComponent) {
-    vnode.children.forEach(v => {
-        patch(v, container, parentComponent);
-    });
+function createTextVNode(text) {
+    return createVNode(Text, {}, text);
 }
-// 处理组件
-function processComponent(vnode, container, parentComponent) {
-    mountComponent(vnode, container, parentComponent);
-}
-// 挂载组件
-function mountComponent(initialVNode, container, parentComponent) {
-    const instance = createComponentInstance(initialVNode, parentComponent);
-    setupComponent(instance);
-    setupRenderEffect(instance, initialVNode, container);
-}
-// 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, initialVNode, container) {
-    const { proxy } = instance;
-    const subTree = instance.render.call(proxy);
-    patch(subTree, container, instance);
-    initialVNode.el = subTree.el;
+function getShapeFlag(type) {
+    return typeof type === 'string' ? ShapeFlags.ELEMENT : ShapeFlags.STATEFUL_COMPONENT;
 }
 
-function createApp(rootComponent) {
-    return {
-        mount(rootContainer) {
-            const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer;
-            const vnode = createVNode(rootComponent);
-            render(vnode, container);
+function createAppApi(render) {
+    return function createApp(rootComponent) {
+        return {
+            mount(rootContainer) {
+                const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer;
+                const vnode = createVNode(rootComponent);
+                render(vnode, container);
+            }
+        };
+    };
+}
+
+function createRenderer(options) {
+    const { createElement, patchProp, insert } = options;
+    function render(vnode, container) {
+        patch(vnode, container, null);
+    }
+    // 判断 vnode 类型，区分处理
+    function patch(vnode, container, parentComponent) {
+        const { type, shapeFlag } = vnode;
+        switch (type) {
+            case Fragment:
+                processFragment(vnode, container, parentComponent);
+                break;
+            case Text:
+                processText(vnode, container);
+                break;
+            default:
+                if (shapeFlag & ShapeFlags.ELEMENT) {
+                    // 判断 vnode 类型为 ELEMENT：调用 processElement
+                    processElement(vnode, container, parentComponent);
+                }
+                else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                    // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                    processComponent(vnode, container, parentComponent);
+                }
+                break;
         }
+    }
+    // 处理 Fragment
+    function processFragment(vnode, container, parentComponent) {
+        mountChildren(vnode, container, parentComponent);
+    }
+    // 处理 Text
+    function processText(vnode, container) {
+        const { children } = vnode;
+        const el = vnode.el = document.createTextNode(children);
+        container.append(el);
+    }
+    // 处理 Element
+    function processElement(vnode, container, parentComponent) {
+        mountElement(vnode, container, parentComponent);
+    }
+    // 挂载 Element
+    function mountElement(vnode, container, parentComponent) {
+        // create el & save el to vnode
+        const el = (vnode.el = createElement(vnode.type));
+        // children
+        const { children, shapeFlag } = vnode;
+        if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
+            el.textContent = children;
+        }
+        else if (shapeFlag & ShapeFlags.ARRAY_CHILREN) {
+            // handle multiple childrens
+            mountChildren(vnode, el, parentComponent);
+        }
+        // props
+        const { props } = vnode;
+        for (const key in props) {
+            const val = props[key];
+            patchProp(el, key, val);
+        }
+        // el append to container
+        insert(el, container);
+    }
+    // 挂载 children 数组，循环调用 patch
+    function mountChildren(vnode, container, parentComponent) {
+        vnode.children.forEach(v => {
+            patch(v, container, parentComponent);
+        });
+    }
+    // 处理组件
+    function processComponent(vnode, container, parentComponent) {
+        mountComponent(vnode, container, parentComponent);
+    }
+    // 挂载组件
+    function mountComponent(initialVNode, container, parentComponent) {
+        const instance = createComponentInstance(initialVNode, parentComponent);
+        setupComponent(instance);
+        setupRenderEffect(instance, initialVNode, container);
+    }
+    // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
+    function setupRenderEffect(instance, initialVNode, container) {
+        const { proxy } = instance;
+        const subTree = instance.render.call(proxy);
+        patch(subTree, container, instance);
+        initialVNode.el = subTree.el;
+    }
+    return {
+        createApp: createAppApi(render)
     };
 }
 
@@ -401,4 +405,23 @@ function inject(key) {
     }
 }
 
-export { createApp, createTextVNode, getCurrentInstance, h, inject, provide, renderSlots };
+function createElement(type) {
+    return document.createElement(type);
+}
+function patchProp(el, key, value) {
+    if (isOn(key)) {
+        el.addEventListener(getEventNameByKey(key), value);
+    }
+    else {
+        el.setAttribute(key, value);
+    }
+}
+function insert(el, parent) {
+    parent.append(el);
+}
+const renderer = createRenderer({ createElement, patchProp, insert });
+function createApp(...args) {
+    return renderer.createApp(...args);
+}
+
+export { createApp, createRenderer, createTextVNode, getCurrentInstance, h, inject, provide, renderSlots };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './runtime-core/index'
+// yolo-vue3 出口
+export * from './runtime-dom'

--- a/src/runtime-core/createApp.ts
+++ b/src/runtime-core/createApp.ts
@@ -1,12 +1,13 @@
 import { createVNode } from './vnode'
-import { render } from './renderer'
 
-export function createApp(rootComponent) {
-    return {
-        mount(rootContainer) {
-            const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer
-            const vnode = createVNode(rootComponent)
-            render(vnode, container)
+export function createAppApi(render) {
+    return function createApp(rootComponent) {
+        return {
+            mount(rootContainer) {
+                const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer
+                const vnode = createVNode(rootComponent)
+                render(vnode, container)
+            }
         }
     }
 }

--- a/src/runtime-core/index.ts
+++ b/src/runtime-core/index.ts
@@ -1,6 +1,6 @@
-export { createApp } from "./createApp";
 export { h } from './h'
 export { renderSlots } from './helpers/renderSlots'
 export { createTextVNode } from './vnode'
 export { getCurrentInstance } from './component'
 export { provide, inject} from './apiInject'
+export { createRenderer } from './renderer'

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -1,104 +1,108 @@
 import { ShapeFlags } from "../shared/ShapeFlags"
-import { getEventNameByKey, isObject, isOn } from "../shared/index"
 import { createComponentInstance, setupComponent } from "./component"
+import { createAppApi } from "./createApp"
 import { Fragment, Text } from "./vnode"
 
-export function render(vnode, container) {
-    patch(vnode, container, null)
-}
+export function createRenderer(options) {
+    const { createElement, patchProp, insert } = options
 
-// 判断 vnode 类型，区分处理
-function patch(vnode, container, parentComponent) {
-    const { type, shapeFlag } = vnode
-    switch (type) {
-        case Fragment:
-            processFragment(vnode, container, parentComponent)
-            break;
-        case Text:
-            processText(vnode, container)
-            break;
-        default:
-            if (shapeFlag & ShapeFlags.ELEMENT) {
-                // 判断 vnode 类型为 ELEMENT：调用 processElement
-                processElement(vnode, container, parentComponent)
-            } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
-                // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                processComponent(vnode, container, parentComponent)
-            }
-            break;
-    }
-  
-}
-
-// 处理 Fragment
-function processFragment(vnode: any, container: any, parentComponent) {
-    mountChildren(vnode, container, parentComponent)
-}
-
-// 处理 Text
-function processText(vnode: any, container: any) {
-    const { children } = vnode
-    const el = vnode.el = document.createTextNode(children)
-    container.append(el)
-}
-
-// 处理 Element
-function processElement(vnode: any, container: any, parentComponent) {
-    mountElement(vnode, container, parentComponent)
-}
-
-// 挂载 Element
-function mountElement(vnode: any, container: any, parentComponent) {
-    // create el & save el to vnode
-    const el = (vnode.el = document.createElement(vnode.type) as Element)
-
-    // children
-    const { children, shapeFlag } = vnode
-    if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
-        el.textContent = children
-    } else if(shapeFlag & ShapeFlags.ARRAY_CHILREN) {
-        // handle multiple childrens
-        mountChildren(vnode, el, parentComponent)
+    function render(vnode, container) {
+        patch(vnode, container, null)
     }
 
-    // props
-    const { props } = vnode
-    for (const key in props) {
-        if (isOn(key)) {
-            el.addEventListener(getEventNameByKey(key), props[key])
-        } else {
-            el.setAttribute(key, props[key])
+    // 判断 vnode 类型，区分处理
+    function patch(vnode, container, parentComponent) {
+        const { type, shapeFlag } = vnode
+        switch (type) {
+            case Fragment:
+                processFragment(vnode, container, parentComponent)
+                break;
+            case Text:
+                processText(vnode, container)
+                break;
+            default:
+                if (shapeFlag & ShapeFlags.ELEMENT) {
+                    // 判断 vnode 类型为 ELEMENT：调用 processElement
+                    processElement(vnode, container, parentComponent)
+                } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
+                    // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
+                    processComponent(vnode, container, parentComponent)
+                }
+                break;
         }
+    
     }
 
-    // el append to container
-    container.append(el)
-}
+    // 处理 Fragment
+    function processFragment(vnode: any, container: any, parentComponent) {
+        mountChildren(vnode, container, parentComponent)
+    }
 
-// 挂载 children 数组，循环调用 patch
-function mountChildren(vnode, container, parentComponent) {
-    vnode.children.forEach(v => {
-        patch(v, container, parentComponent)
-    });
-}
+    // 处理 Text
+    function processText(vnode: any, container: any) {
+        const { children } = vnode
+        const el = vnode.el = document.createTextNode(children)
+        container.append(el)
+    }
 
-// 处理组件
-function processComponent(vnode, container, parentComponent) {
-    mountComponent(vnode, container, parentComponent)
-}
+    // 处理 Element
+    function processElement(vnode: any, container: any, parentComponent) {
+        mountElement(vnode, container, parentComponent)
+    }
 
-// 挂载组件
-function mountComponent(initialVNode, container, parentComponent) {
-    const instance = createComponentInstance(initialVNode, parentComponent)
-    setupComponent(instance)
-    setupRenderEffect(instance, initialVNode, container)
-}
+    // 挂载 Element
+    function mountElement(vnode: any, container: any, parentComponent) {
+        // create el & save el to vnode
+        const el = (vnode.el = createElement(vnode.type) as Element)
 
-// 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
-function setupRenderEffect(instance, initialVNode, container) {
-    const { proxy } = instance
-    const subTree = instance.render.call(proxy)
-    patch(subTree, container, instance)
-    initialVNode.el = subTree.el
-}
+        // children
+        const { children, shapeFlag } = vnode
+        if (shapeFlag & ShapeFlags.TEXT_CHILDREN) {
+            el.textContent = children
+        } else if(shapeFlag & ShapeFlags.ARRAY_CHILREN) {
+            // handle multiple childrens
+            mountChildren(vnode, el, parentComponent)
+        }
 
+        // props
+        const { props } = vnode
+        for (const key in props) {
+            const val = props[key]
+            patchProp(el, key, val)
+        }
+
+        // el append to container
+        insert(el, container)
+    }
+
+    // 挂载 children 数组，循环调用 patch
+    function mountChildren(vnode, container, parentComponent) {
+        vnode.children.forEach(v => {
+            patch(v, container, parentComponent)
+        });
+    }
+
+    // 处理组件
+    function processComponent(vnode, container, parentComponent) {
+        mountComponent(vnode, container, parentComponent)
+    }
+
+    // 挂载组件
+    function mountComponent(initialVNode, container, parentComponent) {
+        const instance = createComponentInstance(initialVNode, parentComponent)
+        setupComponent(instance)
+        setupRenderEffect(instance, initialVNode, container)
+    }
+
+    // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
+    function setupRenderEffect(instance, initialVNode, container) {
+        const { proxy } = instance
+        const subTree = instance.render.call(proxy)
+        patch(subTree, container, instance)
+        initialVNode.el = subTree.el
+    }
+    
+    return {
+        createApp: createAppApi(render)
+    }
+}

--- a/src/runtime-dom/index.ts
+++ b/src/runtime-dom/index.ts
@@ -1,0 +1,26 @@
+import { createRenderer } from "../runtime-core/renderer";
+import { getEventNameByKey, isOn } from "../shared";
+
+function createElement(type) {
+   return document.createElement(type)
+}
+
+function patchProp(el, key, value) {
+if (isOn(key)) {
+        el.addEventListener(getEventNameByKey(key), value)
+    } else {
+        el.setAttribute(key, value)
+    }
+}
+
+function insert(el, parent) {
+    parent.append(el)
+}
+
+const renderer: any = createRenderer({ createElement, patchProp, insert })
+
+export function createApp(...args) {
+    return renderer.createApp(...args)
+}
+
+export * from '../runtime-core'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "esnext",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
**实现 custom renderer**

通过 `createRenderer` 创建自定义 `renderer` 渲染器，替换 `mountElement 挂载组件` 时的操作处理：
1.`createElement` 创建元素处理
2.`patchProp` 挂载属性处理
3.`insert` 元素插入容器处理等

**核心逻辑：**
1. `createRenderer` 函数将 `render`、`patch` 等渲染处理组件/元素的函数包裹，并返回`renderer` 渲染器对象：`{ createApp：createAppAPi(render) }`

2. 因为 `render` 函数被 `createRenderer` 函数包裹无法直接访问，而在 `createApp` 时又需要 `render` 函数来开启渲染流程，所以在 `createRenderer` 中，返回了 `renderer` 渲染器对象：`{ createApp：createAppApi(render) }`，调用 `createAppApi` 函数将 `render` 传入供使用

3. `createAppApi` 函数接收 `render` 渲染函数，并返回 `createApp` 函数，利用闭包特性，`createApp` 可以访问到传入的 `render`，从而正常使用之前已经实现的逻辑，开启渲染：
```javascript
export function createAppApi(render) {
    return function createApp(rootComponent) {
        return {
            mount(rootContainer) {
                const container = typeof rootContainer === 'string' ? document.querySelector(rootContainer) : rootContainer
                const vnode = createVNode(rootComponent)
                render(vnode, container)
            }
        }
    }
}
```

4. 自定义渲染器使用： 
```javascript
// main.js
const renderer = createRenderer(createElement, patchProp, insert)
renderer.createApp(根组件).mount(根容器)
```