### PR TITLE
✨第二十九回: 实现 element 更新主流程

### DIFF
--- a/example/update-element/App.js
+++ b/example/update-element/App.js
@@ -1,0 +1,25 @@
+import { h, ref } from '../../lib/yolo-vue.esm.js'
+
+export const App = {
+    name: 'App',
+    setup() {
+        let count = ref(0)
+        const countClick = () => {
+            count.value++
+            console.log(count.value)
+        }
+        return {
+            count,
+            countClick
+        }
+    },
+    render() {
+        return h(
+            'div', {},
+            [
+                h('p', {}, `count: ${this.count}`),
+                h('button', { onClick: this.countClick }, 'count++')
+            ]
+        )
+    }
+}

--- a/example/update-element/index.html
+++ b/example/update-element/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>hello world</title>
+    <style>
+        .red {
+             color: red;
+        }
+        .green {
+            color: greenyellow;
+        }
+    </style>
+</head>
+<body>
+    <div id="app"></div>
+    <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/example/update-element/main.js
+++ b/example/update-element/main.js
@@ -1,0 +1,4 @@
+import { createApp } from '../../lib/yolo-vue.esm.js'
+import { App } from './App.js'
+
+createApp(App).mount('#app')

--- a/lib/yolo-vue.cjs.js
+++ b/lib/yolo-vue.cjs.js
@@ -1,17 +1,11 @@
 'use strict';
 
-var ShapeFlags;
-(function (ShapeFlags) {
-    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
-    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
-    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
-    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
-    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
-})(ShapeFlags || (ShapeFlags = {}));
-
 const extend = Object.assign;
 const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
+};
+const hasChanged = (value, newValue) => {
+    return !Object.is(value, newValue);
 };
 const isOn = (key) => {
     return /^on[A-z]/.test(key);
@@ -36,6 +30,67 @@ function camelize(str) {
 }
 
 const targetMap = new Map();
+let activeEffect;
+let shouldTrack;
+class ReactiveEffect {
+    constructor(fn, scheduler) {
+        this.deps = [];
+        this.active = true;
+        this._fn = fn;
+        this.scheduler = scheduler;
+    }
+    run() {
+        if (!this.active) {
+            return this._fn();
+        }
+        shouldTrack = true;
+        activeEffect = this;
+        const result = this._fn();
+        shouldTrack = false;
+        return result;
+    }
+    stop() {
+        if (this.active) {
+            cleanupEffect(this);
+            if (this.onStop) {
+                this.onStop();
+            }
+            this.active = false;
+        }
+    }
+}
+function cleanupEffect(effect) {
+    effect.deps.forEach(dep => {
+        dep.delete(effect);
+    });
+    effect.deps.length = 0;
+}
+function track(target, key) {
+    if (!isTracking())
+        return;
+    //  将对象的依赖数组取出
+    let depsMap = targetMap.get(target);
+    if (!depsMap) {
+        depsMap = new Map();
+        targetMap.set(target, depsMap); // [ { user: count }: [] ]
+    }
+    // 将 key 的依赖取数
+    let dep = depsMap.get(key);
+    if (!dep) {
+        dep = new Set();
+        depsMap.set(key, dep); // [ { user: count }: [ count: [] ] ]
+    }
+    trackEffects(dep);
+}
+function trackEffects(dep) {
+    if (dep.has(activeEffect))
+        return;
+    dep.add(activeEffect); // [ { user: count }: [ count: [ ReactiveEffect, ReactiveEffect, ...] ] ]
+    activeEffect.deps.push(dep);
+}
+function isTracking() {
+    return shouldTrack && activeEffect !== undefined;
+}
 function trigger(target, key) {
     // 如果 reactive 对象未使用过 effect，无需 trigger
     if (targetMap.size > 0) {
@@ -56,6 +111,26 @@ function triggerEffects(dep) {
         }
     }
 }
+function effect(fn, options = {}) {
+    // fn
+    const _effect = new ReactiveEffect(fn, options.scheduler);
+    // options
+    extend(_effect, options);
+    _effect.run();
+    // runner
+    const runner = _effect.run.bind(_effect);
+    runner.effect = _effect;
+    return runner;
+}
+
+var ShapeFlags;
+(function (ShapeFlags) {
+    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
+    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
+    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
+    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
+})(ShapeFlags || (ShapeFlags = {}));
 
 const get = createGetter();
 const set = createSetter();
@@ -78,6 +153,10 @@ function createGetter(isReadonly = false, isShallow = false) {
         // 处理嵌套对象
         if (isObject(res)) {
             return isReadonly ? readonly(res) : reactive(res);
+        }
+        // 响应对象收集依赖
+        if (!isReadonly) {
+            track(target, key); // 依赖收集
         }
         return res;
     };
@@ -124,6 +203,71 @@ function createActiveObject(target, baseHandler) {
         return target;
     }
     return new Proxy(target, baseHandler);
+}
+
+// proxy 只接收 objec，不支持基本类型（string，boolean，number）
+// 如 reactive 中一般使用 proxy 来劫持 get/set 进行依赖收集、依赖触发
+// 使用 RefImpl 将 ref(值) 包装成 object，如：{ value: 值 } ，再使用 reactive & proxy 能力 & 逻辑
+class RefImpl {
+    constructor(value) {
+        this.__v__is_ref = true;
+        this._rawValue = value;
+        this._value = convert(value);
+        this.dep = new Set();
+    }
+    get value() {
+        // 当 ref 变量在 effect(fn) 中被使用，effect 会 new ReactiveEffect 来收集依赖
+        // 在 ReactiveEffect 中 run 函数，会初始化 shouldTrack & activeEffect
+        if (isTracking()) {
+            trackEffects(this.dep);
+        }
+        return this._value;
+    }
+    set value(newValue) {
+        if (!hasChanged(newValue, this._rawValue))
+            return;
+        this._rawValue = newValue;
+        this._value = convert(newValue);
+        // 当 ref 变量被 set 时，查看 dep 并触发其所有依赖（ReactiveEffect.run）
+        triggerEffects(this.dep);
+    }
+}
+function convert(value) {
+    return isObject(value) ? reactive(value) : value;
+}
+function isRef(ref) {
+    return !!ref.__v__is_ref;
+}
+function unRef(ref) {
+    // 如果是 ref 对象，返回 ref 下的 value 值
+    // 否则直接返回
+    return isRef(ref) ? ref.value : ref;
+}
+function ref(value) {
+    return new RefImpl(value);
+}
+function proxyRefs(objectWithRefs) {
+    return new Proxy(objectWithRefs, {
+        get(target, key) {
+            // 获取属性值，如果是 ref，节省 .value 步骤直接获取
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age
+            return unRef(Reflect.get(target, key));
+        },
+        set(target, key, value) {
+            // 设置属性值，如果是 ref，节省 .value 步骤直接设置
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age = 20
+            // 如果 target[key] 是 ref, 但 value 不是 ref, 将 value 赋值到 target[key].value，以节省 .value 步骤
+            if (isRef(target[key]) && !isRef(value)) {
+                return target[key].value = value;
+            }
+            else {
+                // 其他情况直接赋值
+                // 同是 ref 赋值：const user = proxyRefs({ age: ref(18) }) -> user.age = ref(20)
+                // 非 ref 赋值 ref：const user = proxyRefs({ age: 18 }) -> user.age = ref(20)
+                return Reflect.set(target, key, value);
+            }
+        }
+    });
 }
 
 // instance 通过上层对 emit 函数 bind(null, instance) 绑定第一个参数为当前 instance
@@ -188,6 +332,8 @@ function createComponentInstance(vnode, parent) {
         slots: {},
         provides: parent ? parent.provides : {},
         parent,
+        isMounted: false,
+        subTree: {},
         emit: () => { }
     };
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -219,7 +365,7 @@ function handleSetupResult(instance, setupResult) {
     // TODO function
     // object
     if (typeof setupResult === 'object') {
-        instance.setupState = setupResult;
+        instance.setupState = proxyRefs(setupResult);
     }
     finishComponentSetup(instance);
 }
@@ -281,44 +427,58 @@ function createAppApi(render) {
 
 function createRenderer(options) {
     const { createElement, patchProp, insert } = options;
+    // 开启渲染
     function render(vnode, container) {
-        patch(vnode, container, null);
+        patch(null, vnode, container, null);
     }
+    // n1：旧的vnode n2：新的vnode
     // 判断 vnode 类型，区分处理
-    function patch(vnode, container, parentComponent) {
-        const { type, shapeFlag } = vnode;
+    function patch(n1, n2, container, parentComponent) {
+        const { type, shapeFlag } = n2;
         switch (type) {
             case Fragment:
-                processFragment(vnode, container, parentComponent);
+                processFragment(n1, n2, container, parentComponent);
                 break;
             case Text:
-                processText(vnode, container);
+                processText(n1, n2, container);
                 break;
             default:
                 if (shapeFlag & ShapeFlags.ELEMENT) {
                     // 判断 vnode 类型为 ELEMENT：调用 processElement
-                    processElement(vnode, container, parentComponent);
+                    processElement(n1, n2, container, parentComponent);
                 }
                 else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
                     // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                    processComponent(vnode, container, parentComponent);
+                    processComponent(n1, n2, container, parentComponent);
                 }
                 break;
         }
     }
     // 处理 Fragment
-    function processFragment(vnode, container, parentComponent) {
-        mountChildren(vnode, container, parentComponent);
+    function processFragment(n1, n2, container, parentComponent) {
+        mountChildren(n2, container, parentComponent);
     }
     // 处理 Text
-    function processText(vnode, container) {
-        const { children } = vnode;
-        const el = vnode.el = document.createTextNode(children);
+    function processText(n1, n2, container) {
+        const { children } = n2;
+        const el = n2.el = document.createTextNode(children);
         container.append(el);
     }
     // 处理 Element
-    function processElement(vnode, container, parentComponent) {
-        mountElement(vnode, container, parentComponent);
+    function processElement(n1, n2, container, parentComponent) {
+        if (!n1) {
+            mountElement(n2, container, parentComponent);
+        }
+        else {
+            patchElement(n1, n2);
+        }
+    }
+    function patchElement(n1, n2, container) {
+        console.log('update patchElement');
+        console.log('n1', n1);
+        console.log('n2', n2);
+        // 对比 props
+        // 对比 children
     }
     // 挂载 Element
     function mountElement(vnode, container, parentComponent) {
@@ -345,12 +505,12 @@ function createRenderer(options) {
     // 挂载 children 数组，循环调用 patch
     function mountChildren(vnode, container, parentComponent) {
         vnode.children.forEach(v => {
-            patch(v, container, parentComponent);
+            patch(null, v, container, parentComponent);
         });
     }
     // 处理组件
-    function processComponent(vnode, container, parentComponent) {
-        mountComponent(vnode, container, parentComponent);
+    function processComponent(n1, n2, container, parentComponent) {
+        mountComponent(n2, container, parentComponent);
     }
     // 挂载组件
     function mountComponent(initialVNode, container, parentComponent) {
@@ -360,10 +520,25 @@ function createRenderer(options) {
     }
     // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
     function setupRenderEffect(instance, initialVNode, container) {
-        const { proxy } = instance;
-        const subTree = instance.render.call(proxy);
-        patch(subTree, container, instance);
-        initialVNode.el = subTree.el;
+        effect(() => {
+            if (!instance.isMounted) {
+                // mount
+                const { proxy } = instance;
+                const subTree = (instance.subTree = instance.render.call(proxy));
+                patch(null, subTree, container, instance);
+                initialVNode.el = subTree.el;
+                instance.isMounted = true;
+            }
+            else {
+                // update
+                const { proxy } = instance;
+                const subTree = instance.render.call(proxy);
+                const prevSubTree = instance.subTree;
+                // 更新当前 subTree 记录，方便与下次 update 对比
+                instance.subTree = subTree;
+                patch(prevSubTree, subTree, container, instance);
+            }
+        });
     }
     return {
         createApp: createAppApi(render)
@@ -433,4 +608,5 @@ exports.getCurrentInstance = getCurrentInstance;
 exports.h = h;
 exports.inject = inject;
 exports.provide = provide;
+exports.ref = ref;
 exports.renderSlots = renderSlots;

--- a/lib/yolo-vue.esm.js
+++ b/lib/yolo-vue.esm.js
@@ -1,15 +1,9 @@
-var ShapeFlags;
-(function (ShapeFlags) {
-    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
-    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
-    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
-    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
-    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
-})(ShapeFlags || (ShapeFlags = {}));
-
 const extend = Object.assign;
 const isObject = (val) => {
     return val !== null && typeof (val) === 'object';
+};
+const hasChanged = (value, newValue) => {
+    return !Object.is(value, newValue);
 };
 const isOn = (key) => {
     return /^on[A-z]/.test(key);
@@ -34,6 +28,67 @@ function camelize(str) {
 }
 
 const targetMap = new Map();
+let activeEffect;
+let shouldTrack;
+class ReactiveEffect {
+    constructor(fn, scheduler) {
+        this.deps = [];
+        this.active = true;
+        this._fn = fn;
+        this.scheduler = scheduler;
+    }
+    run() {
+        if (!this.active) {
+            return this._fn();
+        }
+        shouldTrack = true;
+        activeEffect = this;
+        const result = this._fn();
+        shouldTrack = false;
+        return result;
+    }
+    stop() {
+        if (this.active) {
+            cleanupEffect(this);
+            if (this.onStop) {
+                this.onStop();
+            }
+            this.active = false;
+        }
+    }
+}
+function cleanupEffect(effect) {
+    effect.deps.forEach(dep => {
+        dep.delete(effect);
+    });
+    effect.deps.length = 0;
+}
+function track(target, key) {
+    if (!isTracking())
+        return;
+    //  将对象的依赖数组取出
+    let depsMap = targetMap.get(target);
+    if (!depsMap) {
+        depsMap = new Map();
+        targetMap.set(target, depsMap); // [ { user: count }: [] ]
+    }
+    // 将 key 的依赖取数
+    let dep = depsMap.get(key);
+    if (!dep) {
+        dep = new Set();
+        depsMap.set(key, dep); // [ { user: count }: [ count: [] ] ]
+    }
+    trackEffects(dep);
+}
+function trackEffects(dep) {
+    if (dep.has(activeEffect))
+        return;
+    dep.add(activeEffect); // [ { user: count }: [ count: [ ReactiveEffect, ReactiveEffect, ...] ] ]
+    activeEffect.deps.push(dep);
+}
+function isTracking() {
+    return shouldTrack && activeEffect !== undefined;
+}
 function trigger(target, key) {
     // 如果 reactive 对象未使用过 effect，无需 trigger
     if (targetMap.size > 0) {
@@ -54,6 +109,26 @@ function triggerEffects(dep) {
         }
     }
 }
+function effect(fn, options = {}) {
+    // fn
+    const _effect = new ReactiveEffect(fn, options.scheduler);
+    // options
+    extend(_effect, options);
+    _effect.run();
+    // runner
+    const runner = _effect.run.bind(_effect);
+    runner.effect = _effect;
+    return runner;
+}
+
+var ShapeFlags;
+(function (ShapeFlags) {
+    ShapeFlags[ShapeFlags["ELEMENT"] = 1] = "ELEMENT";
+    ShapeFlags[ShapeFlags["STATEFUL_COMPONENT"] = 2] = "STATEFUL_COMPONENT";
+    ShapeFlags[ShapeFlags["TEXT_CHILDREN"] = 4] = "TEXT_CHILDREN";
+    ShapeFlags[ShapeFlags["ARRAY_CHILREN"] = 8] = "ARRAY_CHILREN";
+    ShapeFlags[ShapeFlags["SLOT_CHILDREN"] = 16] = "SLOT_CHILDREN";
+})(ShapeFlags || (ShapeFlags = {}));
 
 const get = createGetter();
 const set = createSetter();
@@ -76,6 +151,10 @@ function createGetter(isReadonly = false, isShallow = false) {
         // 处理嵌套对象
         if (isObject(res)) {
             return isReadonly ? readonly(res) : reactive(res);
+        }
+        // 响应对象收集依赖
+        if (!isReadonly) {
+            track(target, key); // 依赖收集
         }
         return res;
     };
@@ -122,6 +201,71 @@ function createActiveObject(target, baseHandler) {
         return target;
     }
     return new Proxy(target, baseHandler);
+}
+
+// proxy 只接收 objec，不支持基本类型（string，boolean，number）
+// 如 reactive 中一般使用 proxy 来劫持 get/set 进行依赖收集、依赖触发
+// 使用 RefImpl 将 ref(值) 包装成 object，如：{ value: 值 } ，再使用 reactive & proxy 能力 & 逻辑
+class RefImpl {
+    constructor(value) {
+        this.__v__is_ref = true;
+        this._rawValue = value;
+        this._value = convert(value);
+        this.dep = new Set();
+    }
+    get value() {
+        // 当 ref 变量在 effect(fn) 中被使用，effect 会 new ReactiveEffect 来收集依赖
+        // 在 ReactiveEffect 中 run 函数，会初始化 shouldTrack & activeEffect
+        if (isTracking()) {
+            trackEffects(this.dep);
+        }
+        return this._value;
+    }
+    set value(newValue) {
+        if (!hasChanged(newValue, this._rawValue))
+            return;
+        this._rawValue = newValue;
+        this._value = convert(newValue);
+        // 当 ref 变量被 set 时，查看 dep 并触发其所有依赖（ReactiveEffect.run）
+        triggerEffects(this.dep);
+    }
+}
+function convert(value) {
+    return isObject(value) ? reactive(value) : value;
+}
+function isRef(ref) {
+    return !!ref.__v__is_ref;
+}
+function unRef(ref) {
+    // 如果是 ref 对象，返回 ref 下的 value 值
+    // 否则直接返回
+    return isRef(ref) ? ref.value : ref;
+}
+function ref(value) {
+    return new RefImpl(value);
+}
+function proxyRefs(objectWithRefs) {
+    return new Proxy(objectWithRefs, {
+        get(target, key) {
+            // 获取属性值，如果是 ref，节省 .value 步骤直接获取
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age
+            return unRef(Reflect.get(target, key));
+        },
+        set(target, key, value) {
+            // 设置属性值，如果是 ref，节省 .value 步骤直接设置
+            // 如：const user = proxyRefs({ age: ref(18) }) -> user.age = 20
+            // 如果 target[key] 是 ref, 但 value 不是 ref, 将 value 赋值到 target[key].value，以节省 .value 步骤
+            if (isRef(target[key]) && !isRef(value)) {
+                return target[key].value = value;
+            }
+            else {
+                // 其他情况直接赋值
+                // 同是 ref 赋值：const user = proxyRefs({ age: ref(18) }) -> user.age = ref(20)
+                // 非 ref 赋值 ref：const user = proxyRefs({ age: 18 }) -> user.age = ref(20)
+                return Reflect.set(target, key, value);
+            }
+        }
+    });
 }
 
 // instance 通过上层对 emit 函数 bind(null, instance) 绑定第一个参数为当前 instance
@@ -186,6 +330,8 @@ function createComponentInstance(vnode, parent) {
         slots: {},
         provides: parent ? parent.provides : {},
         parent,
+        isMounted: false,
+        subTree: {},
         emit: () => { }
     };
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -217,7 +363,7 @@ function handleSetupResult(instance, setupResult) {
     // TODO function
     // object
     if (typeof setupResult === 'object') {
-        instance.setupState = setupResult;
+        instance.setupState = proxyRefs(setupResult);
     }
     finishComponentSetup(instance);
 }
@@ -279,44 +425,58 @@ function createAppApi(render) {
 
 function createRenderer(options) {
     const { createElement, patchProp, insert } = options;
+    // 开启渲染
     function render(vnode, container) {
-        patch(vnode, container, null);
+        patch(null, vnode, container, null);
     }
+    // n1：旧的vnode n2：新的vnode
     // 判断 vnode 类型，区分处理
-    function patch(vnode, container, parentComponent) {
-        const { type, shapeFlag } = vnode;
+    function patch(n1, n2, container, parentComponent) {
+        const { type, shapeFlag } = n2;
         switch (type) {
             case Fragment:
-                processFragment(vnode, container, parentComponent);
+                processFragment(n1, n2, container, parentComponent);
                 break;
             case Text:
-                processText(vnode, container);
+                processText(n1, n2, container);
                 break;
             default:
                 if (shapeFlag & ShapeFlags.ELEMENT) {
                     // 判断 vnode 类型为 ELEMENT：调用 processElement
-                    processElement(vnode, container, parentComponent);
+                    processElement(n1, n2, container, parentComponent);
                 }
                 else if (shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
                     // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                    processComponent(vnode, container, parentComponent);
+                    processComponent(n1, n2, container, parentComponent);
                 }
                 break;
         }
     }
     // 处理 Fragment
-    function processFragment(vnode, container, parentComponent) {
-        mountChildren(vnode, container, parentComponent);
+    function processFragment(n1, n2, container, parentComponent) {
+        mountChildren(n2, container, parentComponent);
     }
     // 处理 Text
-    function processText(vnode, container) {
-        const { children } = vnode;
-        const el = vnode.el = document.createTextNode(children);
+    function processText(n1, n2, container) {
+        const { children } = n2;
+        const el = n2.el = document.createTextNode(children);
         container.append(el);
     }
     // 处理 Element
-    function processElement(vnode, container, parentComponent) {
-        mountElement(vnode, container, parentComponent);
+    function processElement(n1, n2, container, parentComponent) {
+        if (!n1) {
+            mountElement(n2, container, parentComponent);
+        }
+        else {
+            patchElement(n1, n2);
+        }
+    }
+    function patchElement(n1, n2, container) {
+        console.log('update patchElement');
+        console.log('n1', n1);
+        console.log('n2', n2);
+        // 对比 props
+        // 对比 children
     }
     // 挂载 Element
     function mountElement(vnode, container, parentComponent) {
@@ -343,12 +503,12 @@ function createRenderer(options) {
     // 挂载 children 数组，循环调用 patch
     function mountChildren(vnode, container, parentComponent) {
         vnode.children.forEach(v => {
-            patch(v, container, parentComponent);
+            patch(null, v, container, parentComponent);
         });
     }
     // 处理组件
-    function processComponent(vnode, container, parentComponent) {
-        mountComponent(vnode, container, parentComponent);
+    function processComponent(n1, n2, container, parentComponent) {
+        mountComponent(n2, container, parentComponent);
     }
     // 挂载组件
     function mountComponent(initialVNode, container, parentComponent) {
@@ -358,10 +518,25 @@ function createRenderer(options) {
     }
     // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
     function setupRenderEffect(instance, initialVNode, container) {
-        const { proxy } = instance;
-        const subTree = instance.render.call(proxy);
-        patch(subTree, container, instance);
-        initialVNode.el = subTree.el;
+        effect(() => {
+            if (!instance.isMounted) {
+                // mount
+                const { proxy } = instance;
+                const subTree = (instance.subTree = instance.render.call(proxy));
+                patch(null, subTree, container, instance);
+                initialVNode.el = subTree.el;
+                instance.isMounted = true;
+            }
+            else {
+                // update
+                const { proxy } = instance;
+                const subTree = instance.render.call(proxy);
+                const prevSubTree = instance.subTree;
+                // 更新当前 subTree 记录，方便与下次 update 对比
+                instance.subTree = subTree;
+                patch(prevSubTree, subTree, container, instance);
+            }
+        });
     }
     return {
         createApp: createAppApi(render)
@@ -424,4 +599,4 @@ function createApp(...args) {
     return renderer.createApp(...args);
 }
 
-export { createApp, createRenderer, createTextVNode, getCurrentInstance, h, inject, provide, renderSlots };
+export { createApp, createRenderer, createTextVNode, getCurrentInstance, h, inject, provide, ref, renderSlots };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 // yolo-vue3 出口
 export * from './runtime-dom'
+export * from './reactivity'

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,0 +1,1 @@
+export { ref } from './ref'

--- a/src/runtime-core/component.ts
+++ b/src/runtime-core/component.ts
@@ -1,4 +1,5 @@
 import { shallowReadonly } from "../reactivity/reactive"
+import { proxyRefs } from "../reactivity/ref"
 import { emit } from "./componentEmit"
 import { initProps } from "./componentProps"
 import { publicInstanceProxyHandlers } from "./componentPublicInstance"
@@ -14,6 +15,8 @@ export function createComponentInstance(vnode: any, parent) {
         slots: {},
         provides: parent ? parent.provides : {},
         parent,
+        isMounted: false,
+        subTree: {},
         emit: () => {}
     }
     // 为 emit 绑定当前组件实例作为第一个参数 instance
@@ -51,7 +54,7 @@ export function handleSetupResult(instance: any, setupResult: any) {
     
     // object
     if(typeof setupResult === 'object') {
-        instance.setupState = setupResult
+        instance.setupState = proxyRefs(setupResult)
     }
     finishComponentSetup(instance)
 }

--- a/src/runtime-core/renderer.ts
+++ b/src/runtime-core/renderer.ts
@@ -1,3 +1,4 @@
+import { effect } from "../reactivity/effect"
 import { ShapeFlags } from "../shared/ShapeFlags"
 import { createComponentInstance, setupComponent } from "./component"
 import { createAppApi } from "./createApp"
@@ -6,27 +7,29 @@ import { Fragment, Text } from "./vnode"
 export function createRenderer(options) {
     const { createElement, patchProp, insert } = options
 
+    // 开启渲染
     function render(vnode, container) {
-        patch(vnode, container, null)
+        patch(null, vnode, container, null)
     }
 
+    // n1：旧的vnode n2：新的vnode
     // 判断 vnode 类型，区分处理
-    function patch(vnode, container, parentComponent) {
-        const { type, shapeFlag } = vnode
+    function patch(n1, n2, container, parentComponent) {
+        const { type, shapeFlag } = n2
         switch (type) {
             case Fragment:
-                processFragment(vnode, container, parentComponent)
+                processFragment(n1, n2, container, parentComponent)
                 break;
             case Text:
-                processText(vnode, container)
+                processText(n1, n2, container)
                 break;
             default:
                 if (shapeFlag & ShapeFlags.ELEMENT) {
                     // 判断 vnode 类型为 ELEMENT：调用 processElement
-                    processElement(vnode, container, parentComponent)
+                    processElement(n1, n2, container, parentComponent)
                 } else if(shapeFlag & ShapeFlags.STATEFUL_COMPONENT) {
                     // 判断 vnode 类型为 STATEFUL_COMPONENT：调用 processComponent
-                    processComponent(vnode, container, parentComponent)
+                    processComponent(n1, n2, container, parentComponent)
                 }
                 break;
         }
@@ -34,20 +37,33 @@ export function createRenderer(options) {
     }
 
     // 处理 Fragment
-    function processFragment(vnode: any, container: any, parentComponent) {
-        mountChildren(vnode, container, parentComponent)
+    function processFragment(n1: any, n2: any, container: any, parentComponent) {
+        mountChildren(n2, container, parentComponent)
     }
 
     // 处理 Text
-    function processText(vnode: any, container: any) {
-        const { children } = vnode
-        const el = vnode.el = document.createTextNode(children)
+    function processText(n1: any, n2: any, container: any) {
+        const { children } = n2
+        const el = n2.el = document.createTextNode(children)
         container.append(el)
     }
 
     // 处理 Element
-    function processElement(vnode: any, container: any, parentComponent) {
-        mountElement(vnode, container, parentComponent)
+    function processElement(n1, n2: any, container: any, parentComponent) {
+        if(!n1) {
+            mountElement(n2, container, parentComponent)
+        } else {
+            patchElement(n1, n2, container)
+        }
+    }
+
+    function patchElement(n1, n2, container) {
+        console.log('update patchElement')
+        console.log('n1', n1)
+        console.log('n2', n2)
+
+        // 对比 props
+        // 对比 children
     }
 
     // 挂载 Element
@@ -78,13 +94,13 @@ export function createRenderer(options) {
     // 挂载 children 数组，循环调用 patch
     function mountChildren(vnode, container, parentComponent) {
         vnode.children.forEach(v => {
-            patch(v, container, parentComponent)
+            patch(null, v, container, parentComponent)
         });
     }
 
     // 处理组件
-    function processComponent(vnode, container, parentComponent) {
-        mountComponent(vnode, container, parentComponent)
+    function processComponent(n1, n2, container, parentComponent) {
+        mountComponent(n2, container, parentComponent)
     }
 
     // 挂载组件
@@ -96,10 +112,28 @@ export function createRenderer(options) {
 
     // 调用 render 获取虚拟节点树 subTree，继续 patch 挂载 component/element
     function setupRenderEffect(instance, initialVNode, container) {
-        const { proxy } = instance
-        const subTree = instance.render.call(proxy)
-        patch(subTree, container, instance)
-        initialVNode.el = subTree.el
+        effect(() => {
+            if(!instance.isMounted) {
+                // mount
+                const { proxy } = instance
+                const subTree = (instance.subTree = instance.render.call(proxy))
+
+                patch(null, subTree, container, instance)
+                initialVNode.el = subTree.el
+                instance.isMounted = true
+            } else {
+                // update
+                const { proxy } = instance
+                const subTree = instance.render.call(proxy)
+                const prevSubTree = instance.subTree
+
+                // 更新当前 subTree 记录，方便与下次 update 对比
+                instance.subTree = subTree
+
+                patch(prevSubTree, subTree, container, instance)
+            }
+            
+        })
     }
     
     return {


### PR DESCRIPTION
**实现 element 更新主流程**

1. 使用 `effect` 将 `setupRenderEffect` 函数代码块包裹，`setupRenderEffect` 函数内调用了组件的渲染函 `instance.render`，如果组件渲染函数 `render` 中使用了响应式对象，`effect` 将收集当前函数为依赖，待该响应式对象更新时，再触发收集的依赖

2. 添加组件属性 `isMounted` 来存储当前组件是否已挂载状态，这样在 `effect` 依赖被重复触发时，可判断当前组件如果已挂载，则走组件更新逻辑

3. 添加组件属性 `subTree` 来存储组件上次的虚拟节点树，在组件更新逻辑下调用 `patch` 函数，并添加 `n1：旧 subTree`，用于对比差异：patch(n1, n2, container, parentComponent)

4. 在 `processElement` 中以 `n1` 参数是否存在，来判断使用更新 `element` 流程

5.  `patchElement` 更新 `element` 流程：对比新老节点的 `props` 、`children` 差异后指定更新（后续利用 `diff` 算法对比）